### PR TITLE
Add endogenous reciprocity to event simulator (first cut for #3)

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -28,12 +28,25 @@
 #'   uniformly at random for each realized event. If \code{n_controls > 0}, the
 #'   function returns a case-control data frame suitable for conditional logistic
 #'   regression / GAM modeling. Defaults to 0.
+#' @param endogenous_stats Optional character vector of endogenous mechanisms to
+#'   include in the rate. Each entry updates a state matrix after every event so
+#'   the intensity of the next event depends on the realized history. Supported
+#'   values: \code{"reciprocity_count"} (number of past reverse-dyad events) and
+#'   \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
+#'   least once). Defaults to \code{NULL} for a memoryless process.
+#' @param endogenous_effects Numeric vector of linear coefficients for
+#'   \code{endogenous_stats}. May be named (names must match
+#'   \code{endogenous_stats}) or unnamed (positionally matched). Required when
+#'   \code{endogenous_stats} is supplied.
 #'
 #' @return If \code{n_controls = 0}, a data.frame with columns \code{sender},
 #'   \code{receiver} and \code{time}. If \code{n_controls > 0}, it returns a
 #'   long-format data.frame with additional columns \code{stratum} (grouping an
 #'   event with its controls) and \code{event} (1 for the realized event,
-#'   0 for controls).
+#'   0 for controls). When \code{endogenous_stats} is supplied, one extra column
+#'   per stat is appended carrying the value each row's dyad had at its event
+#'   time (immediately before the event fired), so downstream conditional
+#'   logistic / GAM estimators can recover the effects.
 #' @export
 #'
 #' @examples
@@ -76,12 +89,46 @@ simulate_relational_events <- function(
     receiver_covariates = NULL,
     receiver_effects = NULL,
     allow_loops = FALSE,
-    n_controls = 0) {
+    n_controls = 0,
+    endogenous_stats = NULL,
+    endogenous_effects = NULL) {
   stopifnot(length(n_events) == 1, n_events > 0)
   stopifnot(length(baseline_rate) == 1, baseline_rate > 0)
   stopifnot(length(start_time) == 1)
   stopifnot(length(horizon) == 1)
   stopifnot(length(n_controls) == 1, n_controls >= 0)
+
+  supported_endogenous <- c("reciprocity_count", "reciprocity_binary")
+  endogenous_active <- !is.null(endogenous_stats) && length(endogenous_stats) > 0
+  if (endogenous_active) {
+    endogenous_stats <- as.character(endogenous_stats)
+    bad <- setdiff(endogenous_stats, supported_endogenous)
+    if (length(bad)) {
+      stop("Unsupported endogenous_stats: ", paste(bad, collapse = ", "),
+           ". Supported: ", paste(supported_endogenous, collapse = ", "), ".")
+    }
+    if (anyDuplicated(endogenous_stats)) {
+      stop("endogenous_stats must not contain duplicates.")
+    }
+    if (is.null(endogenous_effects)) {
+      stop("endogenous_effects must be supplied when endogenous_stats is set.")
+    }
+    eff_names <- names(endogenous_effects)
+    eff_vals <- as.numeric(endogenous_effects)
+    if (length(eff_vals) != length(endogenous_stats)) {
+      stop("endogenous_effects must have the same length as endogenous_stats.")
+    }
+    if (!is.null(eff_names) && !all(eff_names == "")) {
+      if (!setequal(eff_names, endogenous_stats)) {
+        stop("Names of endogenous_effects must match endogenous_stats.")
+      }
+      names(eff_vals) <- eff_names
+      endogenous_effects <- eff_vals[endogenous_stats]
+    } else {
+      names(eff_vals) <- endogenous_stats
+      endogenous_effects <- eff_vals
+    }
+  }
 
   senders <- as.character(senders)
   receivers <- as.character(receivers)
@@ -131,25 +178,47 @@ simulate_relational_events <- function(
     receiver_score <- as.numeric(rc %*% receiver_effects)
   }
 
-  log_weights <- baseline_logits + outer(sender_score, receiver_score, "+")
+  static_log_weights <- baseline_logits + outer(sender_score, receiver_score, "+")
 
   if (!allow_loops) {
     same_actor <- outer(senders, receivers, "==")
-    log_weights[same_actor] <- -Inf
+    static_log_weights[same_actor] <- -Inf
   }
 
-  weights <- exp(log_weights) * baseline_rate
-  weights[!is.finite(weights)] <- 0
-  total_weight <- sum(weights)
-  if (total_weight <= 0) {
-    stop("No admissible dyads with positive intensity.")
+  compute_weights <- function(log_w) {
+    w <- exp(log_w) * baseline_rate
+    w[!is.finite(w)] <- 0
+    tot <- sum(w)
+    if (tot <= 0) {
+      stop("No admissible dyads with positive intensity.")
+    }
+    list(weights = w, total = tot, probs = as.vector(w) / tot,
+         valid = which(w > 0))
   }
 
-  # Normalize weights into probabilities
-  probs <- as.vector(weights) / total_weight
+  endo_state <- list()
+  if (endogenous_active) {
+    for (st in endogenous_stats) {
+      endo_state[[st]] <- matrix(0, nrow = S, ncol = R)
+    }
+  }
 
-  # Ensure enough valid non-events can be sampled if requested
-  valid_dyads <- which(weights > 0)
+  endo_score_matrix <- function() {
+    if (!endogenous_active) {
+      return(NULL)
+    }
+    es <- matrix(0, nrow = S, ncol = R)
+    for (st in endogenous_stats) {
+      es <- es + endogenous_effects[[st]] * endo_state[[st]]
+    }
+    es
+  }
+
+  ww <- compute_weights(static_log_weights)
+  weights <- ww$weights
+  total_weight <- ww$total
+  probs <- ww$probs
+  valid_dyads <- ww$valid
   n_valid_dyads <- length(valid_dyads)
   if (n_controls > 0 && n_controls >= n_valid_dyads) {
     stop("Requested n_controls is >= the number of admissible dyads.")
@@ -166,10 +235,33 @@ simulate_relational_events <- function(
     control_strata <- integer(n_events * n_controls)
   }
 
+  if (endogenous_active) {
+    event_stat_vals <- matrix(0,
+        nrow = n_events, ncol = length(endogenous_stats),
+        dimnames = list(NULL, endogenous_stats))
+    if (n_controls > 0) {
+      control_stat_vals <- matrix(0,
+          nrow = n_events * n_controls, ncol = length(endogenous_stats),
+          dimnames = list(NULL, endogenous_stats))
+    }
+  }
+
   current_time <- start_time
   event_counter <- 0L
 
   for (i in seq_len(n_events)) {
+    if (endogenous_active) {
+      es <- endo_score_matrix()
+      ww <- compute_weights(static_log_weights + es)
+      weights <- ww$weights
+      total_weight <- ww$total
+      probs <- ww$probs
+      valid_dyads <- ww$valid
+      if (n_controls > 0 && n_controls >= length(valid_dyads)) {
+        stop("Requested n_controls is >= the number of admissible dyads at step ", i, ".")
+      }
+    }
+
     # Gillespie timing: rexp(1, rate = sum of all hazards)
     dt <- stats::rexp(1, rate = total_weight)
     current_time <- current_time + dt
@@ -185,6 +277,12 @@ simulate_relational_events <- function(
     event_senders[event_counter] <- senders[s_idx]
     event_receivers[event_counter] <- receivers[r_idx]
     event_times[event_counter] <- current_time
+
+    if (endogenous_active) {
+      for (st in endogenous_stats) {
+        event_stat_vals[event_counter, st] <- endo_state[[st]][s_idx, r_idx]
+      }
+    }
 
     if (n_controls > 0) {
       # Sample 'n_controls' non-events uniformally from valid dyads excluding the chosen one
@@ -208,27 +306,59 @@ simulate_relational_events <- function(
       control_receivers[ctrl_start_idx:ctrl_end_idx] <- receivers[c_r_idxs]
       control_times[ctrl_start_idx:ctrl_end_idx] <- current_time
       control_strata[ctrl_start_idx:ctrl_end_idx] <- event_counter
+
+      if (endogenous_active) {
+        ctrl_rows <- ctrl_start_idx:ctrl_end_idx
+        for (st in endogenous_stats) {
+          control_stat_vals[ctrl_rows, st] <-
+            endo_state[[st]][cbind(c_s_idxs, c_r_idxs)]
+        }
+      }
+    }
+
+    if (endogenous_active) {
+      # Update state matrices using the realized event (s_idx -> r_idx).
+      # The reciprocity stat at candidate dyad (s, r) counts past events
+      # (r -> s); on event (s_idx, r_idx), that contributes to future
+      # reciprocity at dyad (r_idx, s_idx).
+      for (st in endogenous_stats) {
+        if (st == "reciprocity_count") {
+          endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
+        } else if (st == "reciprocity_binary") {
+          endo_state[[st]][r_idx, s_idx] <- 1
+        }
+      }
     }
   }
 
   if (event_counter == 0L) {
     if (n_controls == 0) {
-      return(data.frame(sender = character(0), receiver = character(0), time = numeric(0)))
+      out <- data.frame(sender = character(0), receiver = character(0), time = numeric(0))
     } else {
-      return(data.frame(
+      out <- data.frame(
         stratum = integer(0), event = integer(0),
         sender = character(0), receiver = character(0), time = numeric(0)
-      ))
+      )
     }
+    if (endogenous_active) {
+      for (st in endogenous_stats) out[[st]] <- numeric(0)
+    }
+    return(out)
   }
 
   if (n_controls == 0) {
-    return(data.frame(
+    out <- data.frame(
       sender = event_senders[seq_len(event_counter)],
       receiver = event_receivers[seq_len(event_counter)],
       time = event_times[seq_len(event_counter)],
       stringsAsFactors = FALSE
-    ))
+    )
+    if (endogenous_active) {
+      for (st in endogenous_stats) {
+        out[[st]] <- event_stat_vals[seq_len(event_counter), st]
+      }
+    }
+    return(out)
   } else {
     realized_df <- data.frame(
       stratum = seq_len(event_counter),
@@ -248,6 +378,13 @@ simulate_relational_events <- function(
       time = control_times[seq_len(c_records)],
       stringsAsFactors = FALSE
     )
+
+    if (endogenous_active) {
+      for (st in endogenous_stats) {
+        realized_df[[st]] <- event_stat_vals[seq_len(event_counter), st]
+        control_df[[st]] <- control_stat_vals[seq_len(c_records), st]
+      }
+    }
 
     out <- rbind(realized_df, control_df)
     out <- out[order(out$time, decreasing = FALSE), ]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ simulation-based REM studies:
   endogenous effects (recency, multiple reciprocity forms, transitivity,
   cyclic closure, sending/receiving balance) following Juozaitienė & Wit (2025).
 - **Relational event simulation.** `simulate_relational_events()` runs
-  Gillespie-style simulations with optional controls for partial likelihood.
+  Gillespie-style simulations with optional controls for partial likelihood,
+  including endogenous mechanisms (`reciprocity_count` / `reciprocity_binary`)
+  whose state updates between events.
 - **Non-event sampling.** `sample_non_events()` constructs nested case-control
   tables with appearance, citation, and remove risk-set rules.
 - **Inference-ready design matrices.** Simulations or sampled logs can be fed to
@@ -358,6 +360,37 @@ events <- simulate_relational_events(
 
 See `vignette("exogenous-covariates")` for the full workflow including GAM
 recovery of the non-linear distance effect.
+
+### Endogenous mechanisms during simulation
+
+`simulate_relational_events()` can also drive the next-event rate from the
+realized history. Pass `endogenous_stats` and matching `endogenous_effects`:
+
+```r
+set.seed(2024)
+actors <- as.character(1:10)
+
+cc <- simulate_relational_events(
+  n_events            = 1500,
+  senders             = actors,
+  receivers           = actors,
+  baseline_rate       = 1,
+  allow_loops         = FALSE,
+  n_controls          = 1,
+  endogenous_stats    = "reciprocity_count",
+  endogenous_effects  = 0.6
+)
+
+head(cc[, c("stratum", "event", "sender", "receiver", "reciprocity_count")])
+```
+
+The output gains one column per stat carrying the value each row's dyad had
+at its event time, so the coefficient is directly recoverable by conditional
+logistic / GAM regression on the case–control table (see
+`tests/testthat/test-endogenous-simulation.R`). Supported stats in this first
+cut are `reciprocity_count` and `reciprocity_binary`; additional endogenous
+mechanisms (transitivity, recency, decay-weighted variants) are tracked in
+the issue queue.
 
 ## Documentation
 

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -17,7 +17,9 @@ simulate_relational_events(
   receiver_covariates = NULL,
   receiver_effects = NULL,
   allow_loops = FALSE,
-  n_controls = 0
+  n_controls = 0,
+  endogenous_stats = NULL,
+  endogenous_effects = NULL
 )
 }
 \arguments{
@@ -56,13 +58,28 @@ receiver.}
 uniformly at random for each realized event. If \code{n_controls > 0}, the
 function returns a case-control data frame suitable for conditional logistic
 regression / GAM modeling. Defaults to 0.}
+
+\item{endogenous_stats}{Optional character vector of endogenous mechanisms to
+include in the rate. Each entry updates a state matrix after every event so
+the intensity of the next event depends on the realized history. Supported
+values: \code{"reciprocity_count"} (number of past reverse-dyad events) and
+\code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
+least once). Defaults to \code{NULL} for a memoryless process.}
+
+\item{endogenous_effects}{Numeric vector of linear coefficients for
+\code{endogenous_stats}. May be named (names must match
+\code{endogenous_stats}) or unnamed (positionally matched). Required when
+\code{endogenous_stats} is supplied.}
 }
 \value{
 If \code{n_controls = 0}, a data.frame with columns \code{sender},
 \code{receiver} and \code{time}. If \code{n_controls > 0}, it returns a
 long-format data.frame with additional columns \code{stratum} (grouping an
 event with its controls) and \code{event} (1 for the realized event,
-0 for controls).
+0 for controls). When \code{endogenous_stats} is supplied, one extra column
+per stat is appended carrying the value each row's dyad had at its event
+time (immediately before the event fired), so downstream conditional
+logistic / GAM estimators can recover the effects.
 }
 \description{
 Generate a simple relational event log for a sender set and receiver set

--- a/tests/testthat/test-endogenous-simulation.R
+++ b/tests/testthat/test-endogenous-simulation.R
@@ -1,0 +1,168 @@
+# test-endogenous-simulation.R
+# Coverage for endogenous_stats / endogenous_effects in simulate_relational_events.
+
+test_that("zero endogenous effect reproduces the exogenous-only simulator", {
+  actors <- letters[1:4]
+  args <- list(
+    n_events = 30,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 2,
+    allow_loops = FALSE
+  )
+
+  set.seed(101)
+  base <- do.call(simulate_relational_events, args)
+
+  set.seed(101)
+  endo <- do.call(simulate_relational_events,
+    c(args, list(endogenous_stats = "reciprocity_count",
+                 endogenous_effects = 0)))
+
+  expect_equal(base$sender,   endo$sender)
+  expect_equal(base$receiver, endo$receiver)
+  expect_equal(base$time,     endo$time)
+  expect_true("reciprocity_count" %in% names(endo))
+})
+
+test_that("reciprocity_count column tracks reverse-dyad history correctly", {
+  set.seed(2026)
+  actors <- letters[1:3]
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 5,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = 0
+  )
+
+  expect_true("reciprocity_count" %in% names(ev))
+  expect_equal(nrow(ev), 25L)
+
+  # Verify reciprocity_count[i] = number of past events with sender/receiver
+  # swapped relative to event i.
+  for (i in seq_len(nrow(ev))) {
+    expected <- sum(
+      ev$sender[seq_len(i - 1L)]   == ev$receiver[i] &
+      ev$receiver[seq_len(i - 1L)] == ev$sender[i]
+    )
+    expect_equal(ev$reciprocity_count[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("reciprocity_binary records 0/1 only and matches reciprocity_count > 0", {
+  set.seed(33)
+  actors <- letters[1:3]
+  ev <- simulate_relational_events(
+    n_events = 20,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 5,
+    endogenous_stats = c("reciprocity_binary", "reciprocity_count"),
+    endogenous_effects = c(reciprocity_binary = 0, reciprocity_count = 0)
+  )
+
+  expect_true(all(ev$reciprocity_binary %in% c(0, 1)))
+  expect_equal(as.numeric(ev$reciprocity_count > 0),
+               ev$reciprocity_binary)
+})
+
+test_that("case-control output carries per-row stat values for both events and controls", {
+  set.seed(7)
+  actors <- letters[1:4]
+  cc <- simulate_relational_events(
+    n_events = 10,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 2,
+    n_controls = 2,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = 0
+  )
+
+  expect_true(all(c("stratum", "event", "reciprocity_count") %in% names(cc)))
+  expect_gt(nrow(cc), 10L)
+
+  # All controls within a stratum should share the event's time stamp.
+  for (k in unique(cc$stratum)) {
+    rows <- cc[cc$stratum == k, , drop = FALSE]
+    expect_equal(length(unique(rows$time)), 1L)
+  }
+
+  # Realized-event reciprocity_count must equal the count of past
+  # reverse-dyad realized events (same invariant as the simple log).
+  events_only <- cc[cc$event == 1L, ]
+  events_only <- events_only[order(events_only$stratum), ]
+  for (i in seq_len(nrow(events_only))) {
+    past <- events_only[seq_len(i - 1L), , drop = FALSE]
+    expected <- sum(past$sender == events_only$receiver[i] &
+                    past$receiver == events_only$sender[i])
+    expect_equal(events_only$reciprocity_count[i], expected,
+                 info = paste("stratum", events_only$stratum[i]))
+  }
+})
+
+test_that("validation: unknown stat, missing effects, length mismatch all error", {
+  actors <- letters[1:3]
+  expect_error(
+    simulate_relational_events(n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = "made_up_stat", endogenous_effects = 1),
+    "Unsupported endogenous_stats"
+  )
+  expect_error(
+    simulate_relational_events(n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = "reciprocity_count"),
+    "endogenous_effects must be supplied"
+  )
+  expect_error(
+    simulate_relational_events(n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = c("reciprocity_count", "reciprocity_binary"),
+      endogenous_effects = c(1)),
+    "same length"
+  )
+  expect_error(
+    simulate_relational_events(n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = c("reciprocity_count", "reciprocity_binary"),
+      endogenous_effects = c(wrong_name = 1, reciprocity_count = 2)),
+    "must match"
+  )
+})
+
+test_that("positive reciprocity effect is recoverable via conditional logistic regression", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  set.seed(2024)
+  actors <- as.character(1:10)
+  true_beta <- 0.6
+
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 1,
+    allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = true_beta
+  )
+
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+
+  fit_df <- data.frame(
+    one     = 1,
+    delta_r = cases$reciprocity_count - controls$reciprocity_count
+  )
+
+  fit <- gam(one ~ delta_r - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  # generous interval (single replicate); the point is to catch sign/scale bugs.
+  expect_true(est > 0.3 && est < 0.9,
+              info = sprintf("estimated reciprocity effect = %.3f", est))
+})


### PR DESCRIPTION
Partial fix for #3 — adds endogenous-mechanism support to `simulate_relational_events()`, starting with reciprocity. The remaining mechanisms requested in the issue (transitivity, recency, exp-decay variants) and the distance-with-history example are not in this PR; happy to do follow-up PRs once the API in this one is approved.

## What changed

`simulate_relational_events()` gains two arguments:

- `endogenous_stats`: character vector of mechanism names. Supported in this first cut: `"reciprocity_count"` (number of past reverse-dyad events) and `"reciprocity_binary"` (indicator that the reverse dyad has fired ≥ 1 time).
- `endogenous_effects`: numeric coefficients (optionally named) matching `endogenous_stats`.

When supplied, the simulator maintains a state matrix per stat and recomputes weights at every step, so the next event's intensity reflects the realized history. For reciprocity, state at candidate dyad `(s, r)` counts past events with sender = r and receiver = s — matching the definition in the issue.

When `n_controls > 0`, the case-control output gains **one column per stat** giving the value each row's dyad had at its event time (immediately before the event fired). This makes the coefficients directly recoverable by conditional logistic / GAM on the case-control table.

The **no-endogenous fast path is preserved**: when `endogenous_stats = NULL` the simulator runs the original constant-rate Gillespie loop without per-step recomputation (so no perf regression for existing callers).

## API example

```r
cc <- simulate_relational_events(
  n_events            = 1500,
  senders             = as.character(1:10),
  receivers           = as.character(1:10),
  baseline_rate       = 1,
  allow_loops         = FALSE,
  n_controls          = 1,
  endogenous_stats    = "reciprocity_count",
  endogenous_effects  = 0.6
)
# `cc` now has a `reciprocity_count` column for both events and controls.
```

## Tests

New file `tests/testthat/test-endogenous-simulation.R` covers:

- Zero endogenous effect reproduces the exogenous-only stream byte-for-byte (under matched RNG seed).
- `reciprocity_count` column matches the ground-truth reverse-dyad count for every row.
- `reciprocity_binary == as.numeric(reciprocity_count > 0)`.
- Case-control stat values agree with the realized event history per stratum.
- Validation errors for: unknown stat name, missing effects, length mismatch, name mismatch.
- True β = 0.6 is recovered via GAM on the case-control output (single replicate, generous interval; primarily a sign/scale safety net).

`devtools::test()` — **154 PASS, 0 FAIL** (94 pre-existing + 60 new).

## Files

- `R/simulate_events.R` — new args, validation, state machine, output columns; original fast path unchanged when `endogenous_stats = NULL`.
- `man/simulate_relational_events.Rd` — regenerated.
- `README.md` — feature bullet updated + new "Endogenous mechanisms during simulation" subsection.
- `tests/testthat/test-endogenous-simulation.R` — new.

## Follow-ups (not in this PR)

Open issues already capture these, but for visibility:
- More endogenous stats: transitivity (`transitivity_count`, etc.), recency, exp-decay variants — mirror the catalogue already in `compute_endogenous_features()`.
- Non-linear endogenous effects (smooth `f(stat)` rather than `β * stat`).
- The "distance-with-history" example from the issue (endogenous combined with exogenous distance).
- Tau-leap simulation strategy for #4 (global covariates).

## Note re: #5

This branch is based on `main`, so it still uses the original `baseline_logits` argument name. If #5 (`baseline_logits` → `contribution_logits`) merges first, this PR will need a tiny rebase touching `R/simulate_events.R`, the README example, and the regenerated Rd. Happy to do the rebase whichever direction you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)