### PR TITLE
Address audit findings (HIGH + MEDIUM)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^amore\.Rcheck$
 ^pkgdown$
 ^\.vscode$
+^AUDIT\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .DS_Store
 .vscode/
 Rplots.pdf
+vignettes/*.html

--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -222,6 +222,20 @@ simulate_relational_events <- function(
     stop("Both sender and receiver sets must be non-empty.")
   }
 
+  if (endogenous_active) {
+    # The current endogenous state machinery maintains a single state matrix
+    # indexed by (sender, receiver) and updates the *reverse* dyad after each
+    # event. That update assumes a shared actor universe: senders and
+    # receivers must be the same set in the same order. Without this
+    # restriction the post-event update writes to the wrong cell on
+    # rectangular (bipartite / two-mode) cases.
+    if (S != R || !identical(senders, receivers)) {
+      stop("endogenous_stats currently requires senders and receivers to be ",
+           "the same character vector in the same order (one-mode networks). ",
+           "Bipartite / two-mode support is on the roadmap.")
+    }
+  }
+
   if (is.null(contribution_logits)) {
     contribution_logits <- matrix(0, nrow = S, ncol = R)
   }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,3 +42,4 @@ articles:
     contents:
       - simulation-demo
       - exogenous-covariates
+      - endogenous-and-global

--- a/tests/testthat/test-combined-features.R
+++ b/tests/testthat/test-combined-features.R
@@ -1,0 +1,118 @@
+# test-combined-features.R
+# Exercises endogenous_stats and global_covariates active simultaneously.
+# PR #9 composes the two paths (per-step endogenous recompute + global
+# multiplier rescaling). These tests pin down the joint behaviour.
+
+test_that("zero endogenous + zero global effect matches the global-only zero-effect run", {
+  # The boundary-aware Gillespie path consumes additional rexp draws on every
+  # interval crossing, so it does NOT byte-match the simple (no-global)
+  # simulator under a shared seed. The right invariant is: turning the
+  # endogenous coefficients off should leave the global-only stream
+  # unchanged, since the per-step rate recomputation is a no-op when the
+  # endogenous coefficient vector is zero.
+  actors <- letters[1:4]
+  gc <- data.frame(
+    time_start = c(0, 1, 2, 3, 4),
+    weekday    = c(1, 0, 1, 0, 1)
+  )
+  args <- list(
+    n_events = 25,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 2,
+    horizon = 5,
+    global_covariates = gc,
+    global_effects = c(weekday = 0)
+  )
+
+  set.seed(2026)
+  global_only <- do.call(simulate_relational_events, args)
+
+  set.seed(2026)
+  combined <- do.call(
+    simulate_relational_events,
+    c(args, list(
+      endogenous_stats   = "reciprocity_count",
+      endogenous_effects = c(reciprocity_count = 0)
+    ))
+  )
+
+  expect_equal(global_only$sender,   combined$sender)
+  expect_equal(global_only$receiver, combined$receiver)
+  expect_equal(global_only$time,     combined$time)
+  expect_true(all(c("reciprocity_count", "weekday") %in% names(combined)))
+})
+
+test_that("both stat columns appear with the correct per-row values", {
+  set.seed(99)
+  actors <- letters[1:4]
+  gc <- data.frame(
+    time_start = c(0, 2, 4, 6),
+    weekday    = c(1, 0, 1, 0)
+  )
+
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 1,
+    horizon = 8,
+    endogenous_stats   = c("reciprocity_count", "reciprocity_binary"),
+    endogenous_effects = c(reciprocity_count = 0, reciprocity_binary = 0),
+    global_covariates  = gc,
+    global_effects     = c(weekday = 0)
+  )
+
+  expect_true(all(
+    c("reciprocity_count", "reciprocity_binary", "weekday") %in% names(ev)
+  ))
+
+  # Global column matches the interval at each event time.
+  expected_weekday <- gc$weekday[findInterval(
+    ev$time, gc$time_start, rightmost.closed = FALSE
+  )]
+  expect_equal(ev$weekday, expected_weekday)
+
+  # Endogenous count reproduces the reverse-dyad tally over realized history.
+  for (i in seq_len(nrow(ev))) {
+    past_reverse <- sum(
+      ev$sender[seq_len(i - 1L)]   == ev$receiver[i] &
+      ev$receiver[seq_len(i - 1L)] == ev$sender[i]
+    )
+    expect_equal(ev$reciprocity_count[i], past_reverse, info = paste("row", i))
+    expect_equal(ev$reciprocity_binary[i],
+                 as.numeric(past_reverse > 0),
+                 info = paste("row", i))
+  }
+})
+
+test_that("case-control composition: per-row stat and global values align with each stratum", {
+  set.seed(11)
+  actors <- letters[1:5]
+  gc <- data.frame(time_start = c(0, 1, 2, 3), weekday = c(1, 0, 1, 0))
+
+  cc <- simulate_relational_events(
+    n_events = 12,
+    senders = actors,
+    receivers = actors,
+    baseline_rate = 2,
+    horizon = 4,
+    n_controls = 2,
+    endogenous_stats   = "reciprocity_count",
+    endogenous_effects = c(reciprocity_count = 0),
+    global_covariates  = gc,
+    global_effects     = c(weekday = 0)
+  )
+
+  expect_true(all(
+    c("stratum", "event", "reciprocity_count", "weekday") %in% names(cc)
+  ))
+
+  # Within a stratum, the global covariate value must be constant: events and
+  # their controls share the same event time.
+  for (k in unique(cc$stratum)) {
+    rows <- cc[cc$stratum == k, , drop = FALSE]
+    expect_equal(length(unique(rows$weekday)), 1L)
+    expect_equal(length(unique(rows$time)), 1L)
+  }
+})

--- a/tests/testthat/test-endogenous-simulation.R
+++ b/tests/testthat/test-endogenous-simulation.R
@@ -130,6 +130,45 @@ test_that("validation: unknown stat, missing effects, length mismatch all error"
   )
 })
 
+test_that("endogenous_stats errors clearly on bipartite / two-mode sender/receiver sets", {
+  # The endogenous state machinery indexes a single (S x S) matrix and updates
+  # its reverse dyad after each event. That update assumes senders == receivers
+  # in the same order. The simulator should refuse rectangular / disjoint
+  # actor sets with a clear message rather than silently miscount reciprocity.
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = letters[1:3],
+      receivers = LETTERS[1:3],            # disjoint receiver set
+      endogenous_stats = "reciprocity_count",
+      endogenous_effects = 0.5
+    ),
+    "same character vector"
+  )
+
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = letters[1:3],
+      receivers = letters[1:4],            # different length
+      endogenous_stats = "reciprocity_count",
+      endogenous_effects = 0.5
+    ),
+    "same character vector"
+  )
+
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = letters[1:3],
+      receivers = letters[3:1],            # same set, reordered
+      endogenous_stats = "reciprocity_count",
+      endogenous_effects = 0.5
+    ),
+    "same character vector"
+  )
+})
+
 test_that("positive reciprocity effect is recoverable via conditional logistic regression", {
   skip_on_cran()
   skip_if_not_installed("mgcv")

--- a/tests/testthat/test-global-covariates.R
+++ b/tests/testthat/test-global-covariates.R
@@ -146,6 +146,58 @@ test_that("validation errors fire for malformed global inputs", {
   )
 })
 
+test_that("simulation honours start_time != 0 with matching global intervals", {
+  # start_time = 3, first interval boundary at 3 -> simulation starts on the
+  # 'weekday=1' regime. Events must all sit at time >= 3 and the recorded
+  # weekday column must match the interval each event falls in.
+  set.seed(202)
+  gc <- data.frame(
+    time_start = c(3, 5, 7),
+    weekday    = c(1, 0, 1)
+  )
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = letters[1:4],
+    receivers = letters[1:4],
+    baseline_rate = 1.5,
+    start_time = 3,
+    horizon = 9,
+    global_covariates = gc,
+    global_effects = c(weekday = 0)
+  )
+
+  expect_gt(nrow(ev), 0L)
+  expect_true(all(ev$time >= 3))
+  expect_true(all(ev$time <= 9))
+  expected <- gc$weekday[findInterval(ev$time, gc$time_start,
+                                      rightmost.closed = FALSE)]
+  expect_equal(ev$weekday, expected)
+})
+
+test_that("start_time != 0 with first time_start strictly before start_time still works", {
+  set.seed(303)
+  gc <- data.frame(
+    time_start = c(0, 4, 8),
+    weekday    = c(1, 0, 1)
+  )
+  ev <- simulate_relational_events(
+    n_events = 15,
+    senders = letters[1:3],
+    receivers = letters[1:3],
+    baseline_rate = 2,
+    start_time = 5,           # starts mid second interval (weekday = 0)
+    horizon = 10,
+    global_covariates = gc,
+    global_effects = c(weekday = 0)
+  )
+
+  expect_gt(nrow(ev), 0L)
+  expect_true(all(ev$time >= 5))
+  expected <- gc$weekday[findInterval(ev$time, gc$time_start,
+                                      rightmost.closed = FALSE)]
+  expect_equal(ev$weekday, expected)
+})
+
 test_that("non-event horizon stop still respects boundaries", {
   # In a single-interval setup the boundary-aware path must behave identically
   # to the simple path: if horizon < first interval boundary, no events fire.

--- a/vignettes/endogenous-and-global.Rmd
+++ b/vignettes/endogenous-and-global.Rmd
@@ -1,0 +1,144 @@
+---
+title: "Endogenous mechanisms and time-varying global covariates"
+author: "Francisco Richter"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Endogenous mechanisms and time-varying global covariates}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+    collapse = TRUE,
+    comment = "#>",
+    fig.width = 6,
+    fig.height = 4
+)
+```
+
+```{r}
+library(amore)
+```
+
+Beyond static dyadic covariates, the rate at which relational events fire
+typically depends on *what has already happened* (endogenous mechanisms such as
+reciprocity) and on *when in time* the process is observed (time-varying global
+factors such as weekday/weekend). `simulate_relational_events()` exposes both
+through the `endogenous_stats` / `endogenous_effects` and `global_covariates` /
+`global_effects` argument families. This vignette walks through a minimal
+example for each, then shows how they compose.
+
+## Endogenous reciprocity
+
+`reciprocity_count` is a built-in endogenous statistic: the value of the
+statistic at candidate dyad `(s, r)` is the number of past events `(r, s)`. A
+positive coefficient means an event raises the future rate of its reverse
+dyad.
+
+```{r}
+set.seed(2024)
+actors <- as.character(1:10)
+true_beta <- 0.6
+
+cc <- simulate_relational_events(
+  n_events = 1200,
+  senders = actors,
+  receivers = actors,
+  baseline_rate = 1,
+  allow_loops = FALSE,
+  n_controls = 1,
+  endogenous_stats = "reciprocity_count",
+  endogenous_effects = true_beta
+)
+head(cc)
+```
+
+Recover the coefficient with a one-parameter conditional logit fit on the
+within-stratum statistic difference:
+
+```{r, message=FALSE, warning=FALSE}
+library(mgcv)
+cases    <- cc[cc$event == 1L, ]
+controls <- cc[cc$event == 0L, ]
+cases    <- cases[order(cases$stratum), ]
+controls <- controls[order(controls$stratum), ]
+fit_df <- data.frame(
+  one     = 1,
+  delta_r = cases$reciprocity_count - controls$reciprocity_count
+)
+fit <- gam(one ~ delta_r - 1, family = "binomial", data = fit_df)
+unname(coef(fit)[1])
+```
+
+The estimate sits in the same ballpark as the simulated `true_beta = 0.6`.
+
+## Time-varying global covariates
+
+`global_covariates` is a data.frame with a strictly increasing `time_start`
+column and one numeric column per global covariate. Between two breaks the
+covariate value is constant. Internally, `simulate_relational_events()` uses a
+boundary-aware Gillespie scheme that redraws the next waiting time whenever
+the proposed event would jump into the next interval.
+
+```{r}
+set.seed(2024)
+gc <- data.frame(
+  time_start = seq(0, 10, by = 1),
+  weekday    = rep(c(0, 1), length.out = 11)
+)
+ev <- simulate_relational_events(
+  n_events = 200,
+  senders = letters[1:5],
+  receivers = letters[1:5],
+  baseline_rate = 0.3,
+  horizon = 11,
+  global_covariates = gc,
+  global_effects = c(weekday = 3)
+)
+
+share_weekday <- mean(ev$weekday == 1)
+share_weekday
+```
+
+With `exp(3) ~= 20` weekday-to-weekend rate ratio, the bulk of realised events
+falls in `weekday == 1` intervals.
+
+## Composing endogenous and global
+
+The two features can be active at the same time. The per-step total weight is
+recomputed from the current endogenous state and then rescaled by the global
+multiplier. The output frame carries one column per endogenous statistic and
+one column per global covariate.
+
+```{r}
+set.seed(7)
+actors <- letters[1:5]
+gc <- data.frame(time_start = c(0, 2, 4, 6), weekday = c(1, 0, 1, 0))
+
+ev <- simulate_relational_events(
+  n_events = 60,
+  senders = actors,
+  receivers = actors,
+  baseline_rate = 1,
+  horizon = 7,
+  endogenous_stats = "reciprocity_count",
+  endogenous_effects = c(reciprocity_count = 0.4),
+  global_covariates = gc,
+  global_effects = c(weekday = 1.5)
+)
+head(ev)
+```
+
+Both the `reciprocity_count` column (endogenous state at event time) and the
+`weekday` column (global covariate at event time) appear in the output,
+ready for downstream conditional-logit or partial-likelihood inference.
+
+## Caveat
+
+The current endogenous-state implementation maintains a single
+`(senders × receivers)` reciprocity matrix and requires `senders` and
+`receivers` to be the same character vector in the same order (a one-mode
+network). Passing different sender/receiver sets while using
+`endogenous_stats` will throw a clear error. Bipartite/two-mode support is
+on the roadmap.


### PR DESCRIPTION
Implements the recommended work order from [`AUDIT.md`](AUDIT.md) (2026-05-14).

## HIGH

### Endogenous state index-swap
The reciprocity update in `simulate_relational_events()` writes to `endo_state[[st]][r_idx, s_idx]` on an `S x R` matrix, which only works when senders and receivers are the same set in the same order. Added explicit validation at the top of the function that errors out when `endogenous_stats` is active and `senders` is not `identical()` to `receivers`. A regression test in `tests/testthat/test-endogenous-simulation.R` confirms the error fires for (a) disjoint sets, (b) different lengths, and (c) same set in reverse order.

Bipartite / two-mode endogenous support (the ambitious unified-actor-universe rewrite) is deferred to a follow-up PR.

### Demo-directory R CMD check warnings
No `demo/` directory exists in the current tree, so `R CMD check` was already reporting 0 warnings before this PR. The only non-standard top-level item flagged was `AUDIT.md` itself; added it to `.Rbuildignore` so the audit file is not bundled into the package tarball. Result: 0 warnings, 3 notes (down from 4).

## MEDIUM

### Combined endogenous + global test
New file `tests/testthat/test-combined-features.R` with three blocks:
1. Zero-effect equivalence against the global-only zero-effect run (the right invariant given that the boundary-aware Gillespie path consumes additional `rexp` draws, so a no-global baseline cannot byte-match under a shared seed).
2. Both stat columns present with correct per-row values (`reciprocity_count`, `reciprocity_binary`, `weekday`).
3. Case-control composition: within a stratum, `time` and `weekday` are constant.

### `start_time != 0` global test
Two new blocks appended to `tests/testthat/test-global-covariates.R`: one with `start_time = 3` aligned to the first `time_start`, one with `start_time = 5` strictly inside the second interval.

### `vignettes/endogenous-and-global.Rmd`
New vignette: motivation paragraph, minimal example for endogenous reciprocity (with one-line GAM coefficient recovery), minimal example for global covariates (with weekday-share check), composed example, and a final caveat paragraph about the one-mode restriction. Knits cleanly. `_pkgdown.yml` updated to list it under `articles`.

## Deferred

- **LOW: enlarge the performance microbenchmark in `demo/`.** No `demo/` directory exists in the tree; the LOW item is moot in current state. Will revisit if a `demo/` is reintroduced.
- **LOW: re-verify `@details` boundary/horizon wording.** Audited the merged `@details` block in `R/simulate_events.R`; the description ("once the cumulative time would exceed this value", boundary-first scheme) is consistent with the merged code. No edit required.
- **NIT: factor the duplicate effects-vector handling.** Pure cosmetics; defer to the next time the function is touched for behaviour reasons.

## Test / check counts

- `devtools::test()`: **284 PASS, 0 FAIL, 0 WARN, 0 SKIP** (up from 183 PASS baseline).
- `devtools::check(args = "--no-manual")`: **0 errors, 0 warnings, 3 notes** (down from 0/2/4).