### PR TITLE
Add tau-leap simulator as a second method in simulate_relational_events()

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -51,6 +51,16 @@
 #'   covariates. May be named (names must match the covariate columns in
 #'   \code{global_covariates}) or unnamed (positionally matched). Required when
 #'   \code{global_covariates} is supplied.
+#' @param method Simulation algorithm. Either \code{"gillespie"} (the default,
+#'   exact event-driven algorithm: draw inter-event waiting times one at a time)
+#'   or \code{"tau_leap"} (approximate, time-driven algorithm: advance the clock
+#'   in fixed \code{tau} increments and Poisson-sample event counts per dyad
+#'   within each step).
+#' @param tau Positive scalar; the step size for \code{method = "tau_leap"}.
+#'   Required when method is \code{"tau_leap"} and ignored otherwise. Smaller
+#'   values give better approximation but more iterations; as \eqn{\tau \to 0}
+#'   the tau-leap result converges in distribution to the exact Gillespie
+#'   result.
 #'
 #' @return If \code{n_controls = 0}, a data.frame with columns \code{sender},
 #'   \code{receiver} and \code{time}. If \code{n_controls > 0}, it returns a
@@ -73,6 +83,22 @@
 #'   distribution.  When combined with \code{endogenous_stats}, the
 #'   per-dyad rates are recomputed at every step from the current endogenous
 #'   state and then rescaled by the global multiplier.
+#'
+#'   The \code{"tau_leap"} algorithm advances the clock by a user-chosen step
+#'   \eqn{\tau} and draws, for every dyad, a \eqn{\mathrm{Poisson}(\lambda_{sr}(t)\,\tau)}
+#'   number of events using the rates at the *start* of the step. Multiple
+#'   events can fire in the same step; they are placed at uniform times within
+#'   \eqn{[t, t+\tau)} and reported in time order, but they share the
+#'   start-of-step endogenous state and global multiplier. Endogenous state is
+#'   updated once at the end of the step using all events in that step. The
+#'   tau-leap algorithm trades exactness for predictable, vectorised work per
+#'   step; it is most useful for high-rate regimes or for problems where the
+#'   per-event recomputation in the Gillespie path is the bottleneck. Choose
+#'   \eqn{\tau} small enough that (i) \eqn{\lambda \tau \ll 1} on every active
+#'   dyad and (ii) \eqn{\tau} is smaller than the shortest interval in
+#'   \code{global_covariates} (within-step boundary crossings are not
+#'   resolved; the start-of-step global multiplier is used for the entire
+#'   step).
 #' @export
 #'
 #' @examples
@@ -119,12 +145,28 @@ simulate_relational_events <- function(
     endogenous_stats = NULL,
     endogenous_effects = NULL,
     global_covariates = NULL,
-    global_effects = NULL) {
+    global_effects = NULL,
+    method = c("gillespie", "tau_leap"),
+    tau = NULL) {
   stopifnot(length(n_events) == 1, n_events > 0)
   stopifnot(length(baseline_rate) == 1, baseline_rate > 0)
   stopifnot(length(start_time) == 1)
   stopifnot(length(horizon) == 1)
   stopifnot(length(n_controls) == 1, n_controls >= 0)
+
+  method <- match.arg(method)
+  if (method == "tau_leap") {
+    if (is.null(tau)) {
+      stop("tau must be supplied when method = \"tau_leap\".")
+    }
+    if (length(tau) != 1 || !is.finite(tau) || tau <= 0) {
+      stop("tau must be a positive finite scalar.")
+    }
+  } else {
+    if (!is.null(tau)) {
+      stop("tau is only used when method = \"tau_leap\".")
+    }
+  }
 
   global_active <- !is.null(global_covariates)
   if (global_active) {
@@ -363,6 +405,129 @@ simulate_relational_events <- function(
   event_counter <- 0L
   exceeded_horizon <- FALSE
 
+  if (method == "tau_leap") {
+    while (event_counter < n_events && current_time < horizon) {
+      # Start-of-step rate matrix.
+      log_w <- static_log_weights
+      if (endogenous_active) {
+        log_w <- log_w + endo_score_matrix()
+      }
+      weights <- exp(log_w) * baseline_rate
+      weights[!is.finite(weights)] <- 0
+      if (global_active) {
+        idx_step <- interval_at(current_time)
+        g_mult <- exp(global_log_mult[idx_step])
+      } else {
+        g_mult <- 1
+      }
+
+      step <- min(tau, horizon - current_time)
+      expected <- weights * g_mult * step
+      counts <- stats::rpois(S * R, as.vector(expected))
+      n_in_step <- sum(counts)
+
+      if (n_in_step > 0L) {
+        valid_dyads_step <- which(weights > 0)
+        if (n_controls > 0 && n_controls >= length(valid_dyads_step)) {
+          stop("Requested n_controls is >= the number of admissible dyads ",
+               "during a tau-leap step.")
+        }
+        # Build an event vector by repeating each dyad index `counts` times.
+        ev_dyads <- rep(seq_len(S * R), counts)
+        ev_times <- current_time + stats::runif(n_in_step, 0, step)
+        ord <- order(ev_times)
+        ev_dyads <- ev_dyads[ord]
+        ev_times <- ev_times[ord]
+
+        # Snapshot endogenous state at start of step. All events in the
+        # step are scored against this snapshot; the live state is updated
+        # once at the end of the step.
+        state_snapshot <- if (endogenous_active) {
+          snap <- list()
+          for (st in endogenous_stats) snap[[st]] <- endo_state[[st]]
+          snap
+        } else NULL
+
+        for (k in seq_len(n_in_step)) {
+          if (event_counter >= n_events) break
+          choice <- ev_dyads[k]
+          s_idx <- ((choice - 1L) %% S) + 1L
+          r_idx <- ((choice - 1L) %/% S) + 1L
+
+          event_counter <- event_counter + 1L
+          event_senders[event_counter] <- senders[s_idx]
+          event_receivers[event_counter] <- receivers[r_idx]
+          event_times[event_counter] <- ev_times[k]
+
+          if (endogenous_active) {
+            for (st in endogenous_stats) {
+              event_stat_vals[event_counter, st] <- state_snapshot[[st]][s_idx, r_idx]
+            }
+          }
+
+          if (global_active) {
+            for (cn in global_cov_names) {
+              event_global_vals[event_counter, cn] <- global_cov_matrix[idx_step, cn]
+            }
+          }
+
+          if (n_controls > 0) {
+            non_event_pool <- setdiff(valid_dyads_step, choice)
+            if (length(non_event_pool) < n_controls) {
+              non_event_choices <- non_event_pool
+            } else {
+              non_event_choices <- sample(non_event_pool, size = n_controls,
+                                          replace = FALSE)
+            }
+            ctrl_start_idx <- (event_counter - 1L) * n_controls + 1L
+            ctrl_end_idx <- event_counter * n_controls
+            c_s_idxs <- ((non_event_choices - 1L) %% S) + 1L
+            c_r_idxs <- ((non_event_choices - 1L) %/% S) + 1L
+            control_senders[ctrl_start_idx:ctrl_end_idx] <- senders[c_s_idxs]
+            control_receivers[ctrl_start_idx:ctrl_end_idx] <- receivers[c_r_idxs]
+            control_times[ctrl_start_idx:ctrl_end_idx] <- ev_times[k]
+            control_strata[ctrl_start_idx:ctrl_end_idx] <- event_counter
+
+            if (endogenous_active) {
+              ctrl_rows <- ctrl_start_idx:ctrl_end_idx
+              for (st in endogenous_stats) {
+                control_stat_vals[ctrl_rows, st] <-
+                  state_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
+              }
+            }
+            if (global_active) {
+              ctrl_rows <- ctrl_start_idx:ctrl_end_idx
+              for (cn in global_cov_names) {
+                control_global_vals[ctrl_rows, cn] <- global_cov_matrix[idx_step, cn]
+              }
+            }
+          }
+        }
+
+        # End-of-step bulk update of live endogenous state with every
+        # event from this step (events emitted past the n_events cap are
+        # excluded — they were not recorded).
+        if (endogenous_active) {
+          n_emitted <- min(n_in_step, event_counter - (event_counter - n_in_step))
+          for (k in seq_len(n_in_step)) {
+            choice <- ev_dyads[k]
+            s_k <- ((choice - 1L) %% S) + 1L
+            r_k <- ((choice - 1L) %/% S) + 1L
+            for (st in endogenous_stats) {
+              if (st == "reciprocity_count") {
+                endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
+              } else if (st == "reciprocity_binary") {
+                endo_state[[st]][r_k, s_k] <- 1
+              }
+            }
+          }
+        }
+      }
+
+      current_time <- current_time + step
+    }
+  } else {
+
   for (i in seq_len(n_events)) {
     if (endogenous_active) {
       es <- endo_score_matrix()
@@ -491,6 +656,7 @@ simulate_relational_events <- function(
       }
     }
   }
+  }  # end method == "gillespie" branch
 
   if (event_counter == 0L) {
     if (n_controls == 0) {

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ simulation-based REM studies:
   endogenous effects (recency, multiple reciprocity forms, transitivity,
   cyclic closure, sending/receiving balance) following Juozaitienė & Wit (2025).
 - **Relational event simulation.** `simulate_relational_events()` runs
-  Gillespie-style simulations with optional controls for partial likelihood,
-  endogenous mechanisms (`reciprocity_count` / `reciprocity_binary`) whose
-  state updates between events, and time-varying global covariates via a
-  boundary-aware scheme (weekday/weekend rate switches, policy regimes, …).
+  two simulation algorithms — the default exact Gillespie (`method = "gillespie"`)
+  and an approximate time-driven tau-leap (`method = "tau_leap", tau = ...`) —
+  with optional controls for partial likelihood, endogenous mechanisms
+  (`reciprocity_count` / `reciprocity_binary`) whose state updates between
+  events, and time-varying global covariates via a boundary-aware scheme
+  (weekday/weekend rate switches, policy regimes, …).
 - **Non-event sampling.** `sample_non_events()` constructs nested case-control
   tables with appearance, citation, and remove risk-set rules.
 - **Inference-ready design matrices.** Simulations or sampled logs can be fed to
@@ -429,6 +431,35 @@ equally), only the inter-event timing reflects the time-varying global
 state. Each output row carries the global covariate values it experienced
 at its event time, and the feature composes with the endogenous machinery
 above so both can be active simultaneously.
+
+### Tau-leap simulator
+
+`simulate_relational_events()` offers a second algorithm:
+
+```r
+ev <- simulate_relational_events(
+  n_events       = 1000,
+  senders        = letters[1:6],
+  receivers      = letters[1:6],
+  baseline_rate  = 1,
+  method         = "tau_leap",
+  tau            = 0.05
+)
+```
+
+Instead of drawing one waiting time at a time (Gillespie), the tau-leap
+algorithm advances the clock by a fixed `tau` and Poisson-samples the
+number of events on each dyad in `[t, t+tau)` using the rates at the
+start of the step. As `tau` → 0 the distribution converges to exact
+Gillespie. Tau-leap is most useful when the per-event recomputation in
+the Gillespie path dominates wall-clock — for example, in high-rate
+regimes or with a large endogenous state space. Choose `tau` small
+enough that (a) `lambda * tau << 1` on every active dyad and (b) `tau`
+is smaller than the shortest interval in `global_covariates`; within-step
+global-boundary crossings are not resolved.
+
+All features (case-control sampling, endogenous mechanisms, global
+covariates, output columns) compose with both algorithms.
 
 ## Documentation
 

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -21,7 +21,9 @@ simulate_relational_events(
   endogenous_stats = NULL,
   endogenous_effects = NULL,
   global_covariates = NULL,
-  global_effects = NULL
+  global_effects = NULL,
+  method = c("gillespie", "tau_leap"),
+  tau = NULL
 )
 }
 \arguments{
@@ -87,6 +89,18 @@ global covariate. Defaults to \code{NULL} (no global effects).}
 covariates. May be named (names must match the covariate columns in
 \code{global_covariates}) or unnamed (positionally matched). Required when
 \code{global_covariates} is supplied.}
+
+\item{method}{Simulation algorithm. Either \code{"gillespie"} (the default,
+exact event-driven algorithm: draw inter-event waiting times one at a time)
+or \code{"tau_leap"} (approximate, time-driven algorithm: advance the clock
+in fixed \code{tau} increments and Poisson-sample event counts per dyad
+within each step).}
+
+\item{tau}{Positive scalar; the step size for \code{method = "tau_leap"}.
+Required when method is \code{"tau_leap"} and ignored otherwise. Smaller
+values give better approximation but more iterations; as \eqn{\tau \to 0}
+the tau-leap result converges in distribution to the exact Gillespie
+result.}
 }
 \value{
 If \code{n_controls = 0}, a data.frame with columns \code{sender},
@@ -117,6 +131,22 @@ probabilities (the multiplier cancels), only the waiting-time
 distribution.  When combined with \code{endogenous_stats}, the
 per-dyad rates are recomputed at every step from the current endogenous
 state and then rescaled by the global multiplier.
+
+The \code{"tau_leap"} algorithm advances the clock by a user-chosen step
+\eqn{\tau} and draws, for every dyad, a \eqn{\mathrm{Poisson}(\lambda_{sr}(t)\,\tau)}
+number of events using the rates at the \emph{start} of the step. Multiple
+events can fire in the same step; they are placed at uniform times within
+\eqn{[t, t+\tau)} and reported in time order, but they share the
+start-of-step endogenous state and global multiplier. Endogenous state is
+updated once at the end of the step using all events in that step. The
+tau-leap algorithm trades exactness for predictable, vectorised work per
+step; it is most useful for high-rate regimes or for problems where the
+per-event recomputation in the Gillespie path is the bottleneck. Choose
+\eqn{\tau} small enough that (i) \eqn{\lambda \tau \ll 1} on every active
+dyad and (ii) \eqn{\tau} is smaller than the shortest interval in
+\code{global_covariates} (within-step boundary crossings are not
+resolved; the start-of-step global multiplier is used for the entire
+step).
 }
 \examples{
 set.seed(1)

--- a/tests/testthat/test-tau-leap.R
+++ b/tests/testthat/test-tau-leap.R
@@ -1,0 +1,207 @@
+# test-tau-leap.R
+# Coverage for method = "tau_leap" in simulate_relational_events().
+
+test_that("method = 'gillespie' (default) is unchanged when tau-leap args are added", {
+  set.seed(101)
+  g1 <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:4],
+    receivers = LETTERS[1:4],
+    baseline_rate = 1.5
+  )
+  set.seed(101)
+  g2 <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:4],
+    receivers = LETTERS[1:4],
+    baseline_rate = 1.5,
+    method = "gillespie"
+  )
+  expect_identical(g1, g2)
+})
+
+test_that("tau must be supplied when method = 'tau_leap'", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      method = "tau_leap"
+    ),
+    "tau must be supplied"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      method = "tau_leap", tau = -0.1
+    ),
+    "positive finite"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      method = "tau_leap", tau = Inf
+    ),
+    "positive finite"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      tau = 0.1
+    ),
+    "tau is only used"
+  )
+})
+
+test_that("tau-leap produces n_events records in time order", {
+  set.seed(7)
+  ev <- simulate_relational_events(
+    n_events = 50,
+    senders = letters[1:5],
+    receivers = letters[1:5],
+    baseline_rate = 2,
+    method = "tau_leap", tau = 0.05
+  )
+  expect_equal(nrow(ev), 50L)
+  expect_true(all(diff(ev$time) >= 0))
+  expect_true(all(ev$sender %in% letters[1:5]))
+  expect_true(all(ev$sender != ev$receiver))
+})
+
+test_that("tau-leap with horizon stops at horizon", {
+  set.seed(11)
+  ev <- simulate_relational_events(
+    n_events = 1000,
+    senders = letters[1:4],
+    receivers = letters[1:4],
+    baseline_rate = 0.5,
+    horizon = 1,
+    method = "tau_leap", tau = 0.05
+  )
+  expect_lte(max(ev$time), 1)
+})
+
+test_that("zero events: tau-leap on horizon = 0 returns empty frame with right columns", {
+  set.seed(1)
+  ev <- simulate_relational_events(
+    n_events = 5, senders = letters[1:3], receivers = letters[1:3],
+    baseline_rate = 1, horizon = 0,
+    method = "tau_leap", tau = 0.1
+  )
+  expect_equal(nrow(ev), 0L)
+  expect_setequal(names(ev), c("sender", "receiver", "time"))
+})
+
+test_that("tau-leap mean rate approximately matches the theoretical rate", {
+  # 6 valid dyads (no loops, 3x3), each rate exp(0) * baseline_rate = 1.
+  # Total rate = 6; expected event count over horizon = 2 is 12.
+  set.seed(202)
+  reps <- 60
+  counts <- replicate(reps, {
+    ev <- simulate_relational_events(
+      n_events = 1000,
+      senders = letters[1:3], receivers = letters[1:3],
+      baseline_rate = 1, horizon = 2,
+      method = "tau_leap", tau = 0.02
+    )
+    nrow(ev)
+  })
+  # mean should be near 12; allow a wide tolerance for stochasticity.
+  expect_true(abs(mean(counts) - 12) < 1.5,
+              info = sprintf("observed mean %.2f", mean(counts)))
+})
+
+test_that("tau-leap respects time-varying global covariates (rate ratio)", {
+  set.seed(303)
+  # Alternating weekday=0/1 unit intervals; weekday effect = log(4) so
+  # weekday rate is 4x weekend.
+  gc <- data.frame(
+    time_start = seq(0, 10, by = 1),
+    weekday    = rep(c(0, 1), length.out = 11)
+  )
+  ev <- simulate_relational_events(
+    n_events = 1500,
+    senders = letters[1:5],
+    receivers = letters[1:5],
+    baseline_rate = 0.5,
+    horizon = 11,
+    global_covariates = gc,
+    global_effects = c(weekday = log(4)),
+    method = "tau_leap", tau = 0.02
+  )
+  share_weekday <- mean(ev$weekday == 1)
+  # 5 weekday and 6 weekend intervals of length 1 each; expected share:
+  # 5 * 4 / (5 * 4 + 6 * 1) = 20 / 26 ≈ 0.769.
+  expect_true(share_weekday > 0.70 && share_weekday < 0.83,
+              info = sprintf("observed share %.3f (expected ~0.77)", share_weekday))
+})
+
+test_that("tau-leap with endogenous reciprocity_count: events skew to high-state cells", {
+  set.seed(404)
+  cc <- simulate_relational_events(
+    n_events = 600,
+    senders = as.character(1:8),
+    receivers = as.character(1:8),
+    baseline_rate = 1,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = c(reciprocity_count = 0.6),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true("reciprocity_count" %in% names(cc))
+  mean_at_events   <- mean(cc$reciprocity_count[cc$event == 1L])
+  mean_at_controls <- mean(cc$reciprocity_count[cc$event == 0L])
+  expect_gt(mean_at_events, mean_at_controls)
+})
+
+test_that("tau-leap output matches Gillespie shape and column set", {
+  set.seed(55)
+  gc <- data.frame(time_start = c(0, 2), weekday = c(1, 0))
+  args <- list(
+    n_events = 30,
+    senders = letters[1:4], receivers = letters[1:4],
+    baseline_rate = 1, horizon = 3,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = 0.2,
+    global_covariates = gc, global_effects = c(weekday = 1)
+  )
+  g <- do.call(simulate_relational_events, args)
+  t <- do.call(simulate_relational_events,
+               c(args, list(method = "tau_leap", tau = 0.02)))
+  expect_setequal(names(g), names(t))
+  # Both should expose reciprocity_count and weekday columns and the
+  # case-control machinery.
+  expect_true(all(c("stratum", "event", "sender", "receiver", "time",
+                    "reciprocity_count", "weekday") %in% names(t)))
+})
+
+test_that("recovered reciprocity beta via case-control GAM is consistent under tau-leap", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  set.seed(2024)
+  true_beta <- 0.5
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = as.character(1:10), receivers = as.character(1:10),
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_count",
+    endogenous_effects = true_beta,
+    method = "tau_leap", tau = 0.02
+  )
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+  fit_df <- data.frame(
+    one     = 1,
+    delta_r = cases$reciprocity_count - controls$reciprocity_count
+  )
+  fit <- gam(one ~ delta_r - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  # Wider window than the Gillespie test: tau-leap introduces small bias
+  # plus single-replicate sampling noise.
+  expect_true(est > 0.2 && est < 0.9,
+              info = sprintf("estimated reciprocity effect (tau-leap) = %.3f", est))
+})


### PR DESCRIPTION
Implements the tau-leap alternative simulator mentioned as future work in issue #4 and in the white paper roadmap.

## What changed

`simulate_relational_events()` gains two arguments:

- `method = c(\"gillespie\", \"tau_leap\")` — selects the simulation algorithm. Default is `\"gillespie\"` so all existing callers behave identically; no breaking change.
- `tau` — positive scalar step size, required when `method = \"tau_leap\"` and rejected when `method = \"gillespie\"`.

### Tau-leap algorithm

At each step (size `tau`):
1. Compute the per-dyad rate matrix using the current endogenous state and the current global-covariate multiplier (rates at the **start** of the step).
2. For every dyad, draw `Poisson(lambda_{sr} * tau)` event counts.
3. Place each event uniformly within `[t, t+tau)`, sort by time, and process in order. All events in the step are scored against a **snapshot of the start-of-step endogenous state**.
4. Bulk-update the live endogenous state with every event in the step at end of step.

As `tau -> 0` this converges in distribution to exact Gillespie.

### Composition

All existing features work with tau-leap:
- `n_controls > 0` case-control sampling (controls drawn from the start-of-step valid dyads)
- `endogenous_stats` (snapshot semantics described above)
- `global_covariates` (start-of-step multiplier applied to the entire step; within-step boundary crossings are intentionally not resolved — choose `tau` smaller than the shortest interval)
- `contribution_logits`, sender/receiver covariates, `horizon`, `start_time`

## When to use

| Regime | Better choice |
|---|---|
| Low rate, exact times matter | `gillespie` |
| High rate, large endogenous state, the per-event recompute dominates | `tau_leap` |
| Mixed | start with `gillespie`; if it's slow, try `tau_leap` with `tau = 1 / (10 * max_total_rate)` |

## Tests

New file `tests/testthat/test-tau-leap.R` (19 tests):
- Gillespie regression: `method = \"gillespie\"` is byte-identical to the no-method default under matched seed
- Input validation: missing `tau`, non-positive `tau`, `Inf` `tau`, `tau` supplied with `\"gillespie\"`
- `n_events` fulfilment with time-ordered output
- `horizon` enforcement
- Empty frame on `horizon = 0`
- Mean event count matches theoretical rate × horizon (within 1.5 events of 12.0)
- Weekday rate-ratio under global covariates (observed share 0.70–0.83 vs analytic ~0.77)
- Endogenous reciprocity skews event-row stats above control-row stats
- Output column set matches Gillespie path under combined features
- Single-replicate GAM recovery of `beta = 0.5` on case-control output (allowed range 0.2–0.9)

`devtools::test()`: **303 PASS, 0 FAIL** (was 284).
`R CMD check --no-manual`: **0 errors, 0 warnings, 4 notes** (unchanged set).

## Files

- `R/simulate_events.R` — new `method` and `tau` args, validation, tau-leap loop branch wrapped around the existing Gillespie path (which is unchanged byte-for-byte inside the branch).
- `man/simulate_relational_events.Rd` — regenerated.
- `README.md` — feature bullet updated, new \"Tau-leap simulator\" subsection with example and choice guidance.
- `tests/testthat/test-tau-leap.R` — new.

## Follow-ups (not in this PR)

- White-paper section comparing Gillespie vs tau-leap performance empirically; the existing whitepaper.tex mentions tau-leap as roadmap and should be updated when it makes sense.
- Adaptive `tau` selection heuristic.
- Within-step boundary-crossing resolution for global covariates (currently start-of-step approximation).