### PR TITLE
Add reciprocity_exp_decay + risk='remove' + species-invasion vignette

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -33,13 +33,24 @@
 #' @param endogenous_stats Optional character vector of endogenous mechanisms to
 #'   include in the rate. Each entry updates a state matrix after every event so
 #'   the intensity of the next event depends on the realized history. Supported
-#'   values: \code{"reciprocity_count"} (number of past reverse-dyad events) and
+#'   values: \code{"reciprocity_count"} (number of past reverse-dyad events),
 #'   \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-#'   least once). Defaults to \code{NULL} for a memoryless process.
+#'   least once), and \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
+#'   events with exponential half-life decay; requires \code{half_life}).
+#'   Defaults to \code{NULL} for a memoryless process.
 #' @param endogenous_effects Numeric vector of linear coefficients for
 #'   \code{endogenous_stats}. May be named (names must match
 #'   \code{endogenous_stats}) or unnamed (positionally matched). Required when
 #'   \code{endogenous_stats} is supplied.
+#' @param half_life Positive scalar; the half-life \eqn{T} (in time units) used
+#'   by the \code{"reciprocity_exp_decay"} stat. A past reverse-dyad event at
+#'   time \eqn{t_k} contributes \eqn{\exp(-(t - t_k)\,\log 2/T)} to the stat
+#'   value at time \eqn{t}. Required when \code{"reciprocity_exp_decay"} is in
+#'   \code{endogenous_stats}.
+#' @param risk Risk-set rule. \code{"standard"} (the default) keeps every dyad
+#'   eligible at every step. \code{"remove"} removes a dyad from the risk set
+#'   as soon as it fires, which mimics one-shot processes such as species
+#'   invasions or first-citation events.
 #' @param global_covariates Optional data.frame describing piecewise-constant
 #'   global covariates: variables whose value at time \eqn{t} is the same for
 #'   every dyad (e.g. weekday/weekend, weather, policy regime). Must contain a
@@ -147,7 +158,10 @@ simulate_relational_events <- function(
     global_covariates = NULL,
     global_effects = NULL,
     method = c("gillespie", "tau_leap"),
-    tau = NULL) {
+    tau = NULL,
+    half_life = NULL,
+    risk = c("standard", "remove")) {
+  risk <- match.arg(risk)
   stopifnot(length(n_events) == 1, n_events > 0)
   stopifnot(length(baseline_rate) == 1, baseline_rate > 0)
   stopifnot(length(start_time) == 1)
@@ -223,7 +237,8 @@ simulate_relational_events <- function(
     global_log_mult <- as.numeric(global_cov_matrix %*% global_effects)
   }
 
-  supported_endogenous <- c("reciprocity_count", "reciprocity_binary")
+  supported_endogenous <- c("reciprocity_count", "reciprocity_binary",
+                            "reciprocity_exp_decay")
   endogenous_active <- !is.null(endogenous_stats) && length(endogenous_stats) > 0
   if (endogenous_active) {
     endogenous_stats <- as.character(endogenous_stats)
@@ -231,6 +246,13 @@ simulate_relational_events <- function(
     if (length(bad)) {
       stop("Unsupported endogenous_stats: ", paste(bad, collapse = ", "),
            ". Supported: ", paste(supported_endogenous, collapse = ", "), ".")
+    }
+    if ("reciprocity_exp_decay" %in% endogenous_stats) {
+      if (is.null(half_life) || length(half_life) != 1 || !is.finite(half_life) ||
+          half_life <= 0) {
+        stop("half_life must be a positive finite scalar when ",
+             "\"reciprocity_exp_decay\" is in endogenous_stats.")
+      }
     }
     if (anyDuplicated(endogenous_stats)) {
       stop("endogenous_stats must not contain duplicates.")
@@ -342,6 +364,29 @@ simulate_relational_events <- function(
     }
   }
 
+  has_exp_decay <- endogenous_active &&
+    "reciprocity_exp_decay" %in% endogenous_stats
+  last_state_time <- start_time
+  if (has_exp_decay) {
+    decay_rate <- log(2) / half_life
+  }
+
+  apply_exp_decay <- function() {
+    # Multiplicative decay of the exp-decay state cell-wise to the current
+    # clock time. Called when reading or snapshotting state so the value
+    # carried is correctly attenuated for the time elapsed since the last
+    # update.
+    if (!has_exp_decay) return(invisible())
+    dt_decay <- current_time - last_state_time
+    if (dt_decay > 0) {
+      decay_factor <- exp(-dt_decay * decay_rate)
+      endo_state[["reciprocity_exp_decay"]] <<-
+        endo_state[["reciprocity_exp_decay"]] * decay_factor
+      last_state_time <<- current_time
+    }
+    invisible()
+  }
+
   endo_score_matrix <- function() {
     if (!endogenous_active) {
       return(NULL)
@@ -407,6 +452,10 @@ simulate_relational_events <- function(
 
   if (method == "tau_leap") {
     while (event_counter < n_events && current_time < horizon) {
+      # Decay exp-decay state up to the start of this step so the rates
+      # used below are correctly attenuated.
+      apply_exp_decay()
+
       # Start-of-step rate matrix.
       log_w <- static_log_weights
       if (endogenous_active) {
@@ -414,6 +463,10 @@ simulate_relational_events <- function(
       }
       weights <- exp(log_w) * baseline_rate
       weights[!is.finite(weights)] <- 0
+      if (sum(weights) <= 0) {
+        if (risk == "remove") break
+        stop("No admissible dyads with positive intensity.")
+      }
       if (global_active) {
         idx_step <- interval_at(current_time)
         g_mult <- exp(global_log_mult[idx_step])
@@ -423,7 +476,16 @@ simulate_relational_events <- function(
 
       step <- min(tau, horizon - current_time)
       expected <- weights * g_mult * step
-      counts <- stats::rpois(S * R, as.vector(expected))
+      if (risk == "remove") {
+        # One-shot dyads: at most one event per dyad per step. Use a
+        # Bernoulli with success probability 1 - exp(-lambda*tau) rather
+        # than Poisson, which would allow more than one event on a dyad
+        # that must be removed after its first firing.
+        p_fire <- 1 - exp(-as.vector(expected))
+        counts <- stats::rbinom(S * R, size = 1, prob = p_fire)
+      } else {
+        counts <- stats::rpois(S * R, as.vector(expected))
+      }
       n_in_step <- sum(counts)
 
       if (n_in_step > 0L) {
@@ -507,18 +569,22 @@ simulate_relational_events <- function(
         # End-of-step bulk update of live endogenous state with every
         # event from this step (events emitted past the n_events cap are
         # excluded — they were not recorded).
-        if (endogenous_active) {
-          n_emitted <- min(n_in_step, event_counter - (event_counter - n_in_step))
+        if (endogenous_active || risk == "remove") {
           for (k in seq_len(n_in_step)) {
             choice <- ev_dyads[k]
             s_k <- ((choice - 1L) %% S) + 1L
             r_k <- ((choice - 1L) %/% S) + 1L
-            for (st in endogenous_stats) {
-              if (st == "reciprocity_count") {
-                endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
-              } else if (st == "reciprocity_binary") {
-                endo_state[[st]][r_k, s_k] <- 1
+            if (endogenous_active) {
+              for (st in endogenous_stats) {
+                if (st == "reciprocity_count" || st == "reciprocity_exp_decay") {
+                  endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
+                } else if (st == "reciprocity_binary") {
+                  endo_state[[st]][r_k, s_k] <- 1
+                }
               }
+            }
+            if (risk == "remove") {
+              static_log_weights[s_k, r_k] <- -Inf
             }
           }
         }
@@ -529,13 +595,24 @@ simulate_relational_events <- function(
   } else {
 
   for (i in seq_len(n_events)) {
-    if (endogenous_active) {
-      es <- endo_score_matrix()
-      ww <- compute_weights(static_log_weights + es)
-      weights <- ww$weights
-      total_weight <- ww$total
-      probs <- ww$probs
-      valid_dyads <- ww$valid
+    if (endogenous_active || risk == "remove") {
+      log_w <- static_log_weights
+      if (endogenous_active) {
+        log_w <- log_w + endo_score_matrix()
+      }
+      weights <- exp(log_w) * baseline_rate
+      weights[!is.finite(weights)] <- 0
+      total_weight <- sum(weights)
+      if (total_weight <= 0) {
+        if (risk == "remove") {
+          # All admissible dyads have fired and been removed -- stop
+          # gracefully and return whatever was produced so far.
+          break
+        }
+        stop("No admissible dyads with positive intensity.")
+      }
+      probs <- as.vector(weights) / total_weight
+      valid_dyads <- which(weights > 0)
       if (n_controls > 0 && n_controls >= length(valid_dyads)) {
         stop("Requested n_controls is >= the number of admissible dyads at step ", i, ".")
       }
@@ -588,6 +665,11 @@ simulate_relational_events <- function(
     event_senders[event_counter] <- senders[s_idx]
     event_receivers[event_counter] <- receivers[r_idx]
     event_times[event_counter] <- current_time
+
+    # Decay exp-decay state up to the event time before snapshotting it,
+    # so the value carried on the output row reflects the time elapsed
+    # since the previous event.
+    apply_exp_decay()
 
     if (endogenous_active) {
       for (st in endogenous_stats) {
@@ -648,12 +730,17 @@ simulate_relational_events <- function(
       # (r -> s); on event (s_idx, r_idx), that contributes to future
       # reciprocity at dyad (r_idx, s_idx).
       for (st in endogenous_stats) {
-        if (st == "reciprocity_count") {
+        if (st == "reciprocity_count" || st == "reciprocity_exp_decay") {
           endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
         } else if (st == "reciprocity_binary") {
           endo_state[[st]][r_idx, s_idx] <- 1
         }
       }
+    }
+
+    if (risk == "remove") {
+      # One-shot dyad: drop it from the risk set so it cannot fire again.
+      static_log_weights[s_idx, r_idx] <- -Inf
     }
   }
   }  # end method == "gillespie" branch

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ simulation-based REM studies:
   two simulation algorithms — the default exact Gillespie (`method = "gillespie"`)
   and an approximate time-driven tau-leap (`method = "tau_leap", tau = ...`) —
   with optional controls for partial likelihood, endogenous mechanisms
-  (`reciprocity_count` / `reciprocity_binary`) whose state updates between
-  events, and time-varying global covariates via a boundary-aware scheme
-  (weekday/weekend rate switches, policy regimes, …).
+  (`reciprocity_count`, `reciprocity_binary`, half-life-decayed
+  `reciprocity_exp_decay`) whose state updates between events, time-varying
+  global covariates via a boundary-aware scheme (weekday/weekend rate
+  switches, policy regimes, …), and a `risk = "remove"` rule for one-shot
+  processes such as species invasions or first-citation events.
 - **Non-event sampling.** `sample_non_events()` constructs nested case-control
   tables with appearance, citation, and remove risk-set rules.
 - **Inference-ready design matrices.** Simulations or sampled logs can be fed to

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -43,3 +43,4 @@ articles:
       - simulation-demo
       - exogenous-covariates
       - endogenous-and-global
+      - species-invasion

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -23,7 +23,9 @@ simulate_relational_events(
   global_covariates = NULL,
   global_effects = NULL,
   method = c("gillespie", "tau_leap"),
-  tau = NULL
+  tau = NULL,
+  half_life = NULL,
+  risk = c("standard", "remove")
 )
 }
 \arguments{
@@ -68,9 +70,11 @@ regression / GAM modeling. Defaults to 0.}
 \item{endogenous_stats}{Optional character vector of endogenous mechanisms to
 include in the rate. Each entry updates a state matrix after every event so
 the intensity of the next event depends on the realized history. Supported
-values: \code{"reciprocity_count"} (number of past reverse-dyad events) and
+values: \code{"reciprocity_count"} (number of past reverse-dyad events),
 \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-least once). Defaults to \code{NULL} for a memoryless process.}
+least once), and \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
+events with exponential half-life decay; requires \code{half_life}).
+Defaults to \code{NULL} for a memoryless process.}
 
 \item{endogenous_effects}{Numeric vector of linear coefficients for
 \code{endogenous_stats}. May be named (names must match
@@ -101,6 +105,17 @@ Required when method is \code{"tau_leap"} and ignored otherwise. Smaller
 values give better approximation but more iterations; as \eqn{\tau \to 0}
 the tau-leap result converges in distribution to the exact Gillespie
 result.}
+
+\item{half_life}{Positive scalar; the half-life \eqn{T} (in time units) used
+by the \code{"reciprocity_exp_decay"} stat. A past reverse-dyad event at
+time \eqn{t_k} contributes \eqn{\exp(-(t - t_k)\,\log 2/T)} to the stat
+value at time \eqn{t}. Required when \code{"reciprocity_exp_decay"} is in
+\code{endogenous_stats}.}
+
+\item{risk}{Risk-set rule. \code{"standard"} (the default) keeps every dyad
+eligible at every step. \code{"remove"} removes a dyad from the risk set
+as soon as it fires, which mimics one-shot processes such as species
+invasions or first-citation events.}
 }
 \value{
 If \code{n_controls = 0}, a data.frame with columns \code{sender},

--- a/tests/testthat/test-decay-and-remove.R
+++ b/tests/testthat/test-decay-and-remove.R
@@ -1,0 +1,176 @@
+# test-decay-and-remove.R
+# Coverage for reciprocity_exp_decay endogenous stat and risk = "remove" rule.
+
+test_that("reciprocity_exp_decay column matches the hand-derived weighted sum", {
+  set.seed(1)
+  half <- 2
+  rate <- log(2) / half
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 2,
+    endogenous_stats = "reciprocity_exp_decay",
+    endogenous_effects = 0,           # zero coefficient -> stat is pure observable
+    half_life = half
+  )
+  # Hand-compute for every row.
+  for (i in seq_len(nrow(ev))) {
+    if (i == 1L) {
+      expect_equal(ev$reciprocity_exp_decay[i], 0, info = paste("row", i))
+      next
+    }
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    reverse_mask <- prior$sender == ev$receiver[i] & prior$receiver == ev$sender[i]
+    expected <- sum(exp(-(ev$time[i] - prior$time[reverse_mask]) * rate))
+    expect_equal(ev$reciprocity_exp_decay[i], expected,
+                 tolerance = 1e-8, info = paste("row", i))
+  }
+})
+
+test_that("reciprocity_exp_decay requires a positive half_life", {
+  actors <- LETTERS[1:3]
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = "reciprocity_exp_decay",
+      endogenous_effects = 0.5
+    ),
+    "half_life must be a positive finite scalar"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = "reciprocity_exp_decay",
+      endogenous_effects = 0.5,
+      half_life = -1
+    ),
+    "half_life must be a positive finite scalar"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 2, senders = actors, receivers = actors,
+      endogenous_stats = "reciprocity_exp_decay",
+      endogenous_effects = 0.5,
+      half_life = Inf
+    ),
+    "half_life must be a positive finite scalar"
+  )
+})
+
+test_that("exp-decay stat composes with reciprocity_count in the same call", {
+  set.seed(42)
+  ev <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 2,
+    endogenous_stats = c("reciprocity_count", "reciprocity_exp_decay"),
+    endogenous_effects = c(reciprocity_count = 0, reciprocity_exp_decay = 0),
+    half_life = 1
+  )
+  expect_true(all(c("reciprocity_count", "reciprocity_exp_decay") %in% names(ev)))
+  # The exp-decay value never exceeds the integer count.
+  expect_true(all(ev$reciprocity_exp_decay <= ev$reciprocity_count + 1e-9))
+  # Their relationship: as half_life -> Inf the two coincide; for finite
+  # half_life, exp_decay <= count.
+  expect_true(all(ev$reciprocity_exp_decay >= 0))
+})
+
+test_that("positive reciprocity_exp_decay effect is recoverable via case-control GAM", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  set.seed(2026)
+  true_beta <- 0.8
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = as.character(1:10), receivers = as.character(1:10),
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_exp_decay",
+    endogenous_effects = true_beta,
+    half_life = 0.5
+  )
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+  fit_df <- data.frame(
+    one     = 1,
+    delta_r = cases$reciprocity_exp_decay - controls$reciprocity_exp_decay
+  )
+  fit <- gam(one ~ delta_r - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.4 && est < 1.3,
+              info = sprintf("estimated decayed reciprocity effect = %.3f", est))
+})
+
+test_that("risk = 'remove' produces unique dyads only", {
+  set.seed(7)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 1, risk = "remove"
+  )
+  expect_false(any(duplicated(paste(ev$sender, ev$receiver))),
+               info = "remove-risk dyads should never repeat")
+})
+
+test_that("risk = 'remove' terminates gracefully when admissible dyads run out", {
+  # 3 actors, no loops -> 6 dyads. Asking for 50 should yield 6 rows.
+  set.seed(11)
+  ev <- simulate_relational_events(
+    n_events = 50,
+    senders = LETTERS[1:3], receivers = LETTERS[1:3],
+    baseline_rate = 1, risk = "remove"
+  )
+  expect_equal(nrow(ev), 6L)
+  expect_false(any(duplicated(paste(ev$sender, ev$receiver))))
+})
+
+test_that("risk = 'remove' composes with case-control sampling", {
+  set.seed(99)
+  cc <- simulate_relational_events(
+    n_events = 10,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 1, n_controls = 1, risk = "remove"
+  )
+  # Realized events are all unique dyads ...
+  events_only <- cc[cc$event == 1L, ]
+  expect_false(any(duplicated(paste(events_only$sender, events_only$receiver))))
+  # ... and the controls drawn in each stratum should not equal the
+  # event in that stratum.
+  for (k in unique(cc$stratum)) {
+    rows <- cc[cc$stratum == k, ]
+    ev_row <- rows[rows$event == 1L, ]
+    ct_rows <- rows[rows$event == 0L, ]
+    expect_false(any(paste(ct_rows$sender, ct_rows$receiver) ==
+                       paste(ev_row$sender, ev_row$receiver)))
+  }
+})
+
+test_that("risk = 'remove' under tau-leap also produces unique dyads", {
+  set.seed(13)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3, risk = "remove",
+    method = "tau_leap", tau = 0.02
+  )
+  expect_false(any(duplicated(paste(ev$sender, ev$receiver))))
+})
+
+test_that("exp-decay + remove + case-control compose with all features", {
+  set.seed(17)
+  cc <- simulate_relational_events(
+    n_events = 15,
+    senders = LETTERS[1:6], receivers = LETTERS[1:6],
+    baseline_rate = 1, n_controls = 1, risk = "remove",
+    endogenous_stats = "reciprocity_exp_decay",
+    endogenous_effects = 0.3,
+    half_life = 1
+  )
+  expect_true(all(c("stratum", "event", "reciprocity_exp_decay") %in% names(cc)))
+  events_only <- cc[cc$event == 1L, ]
+  expect_false(any(duplicated(paste(events_only$sender, events_only$receiver))))
+})

--- a/vignettes/species-invasion.Rmd
+++ b/vignettes/species-invasion.Rmd
@@ -1,0 +1,154 @@
+---
+title: "Species invasions as a relational event process"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Species invasions as a relational event process}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 6,
+  fig.height = 4
+)
+set.seed(2026)
+```
+
+```{r setup}
+library(amore)
+```
+
+## Why model invasions as relational events?
+
+A non-native species establishing in a new country is a one-shot
+directed event: source country `s` "invades" target country `r` at some
+time `t`. Once `s` has reached `r`, the dyad `(s, r)` is removed from
+the at-risk set — it cannot fire again. This is a textbook **relational
+event process** with a one-shot `risk = "remove"` rule.
+
+We sketch a minimal end-to-end workflow in `amore`:
+
+1. Build a synthetic invasion log with known drivers (distance and
+   propagule pressure).
+2. Use the `risk = "remove"` simulator with case-control sampling.
+3. Recover the drivers from the case-control output with a smooth GAM.
+
+## A synthetic invasion process
+
+We use the 56 × 56 US-state distance matrix shipped with `amore` as a
+stand-in for inter-country distances and treat the states as the
+country universe.
+
+```{r data}
+data("dist_matrix", package = "amore")
+
+states <- rownames(dist_matrix)
+n_states <- length(states)
+
+# Convert metres → log-units, scaled to a usable range.
+dist_log <- log(dist_matrix / 1e5 + 1)
+```
+
+The true intensity for an invasion from `s` to `r` is
+
+$$\lambda_{sr}(t) = Y_{sr}(t)\;\lambda_0\;\exp\!\bigl(\beta_d\,f(d_{sr})
++ \beta_h\,h_{sr}(t)\bigr),$$
+
+where $Y_{sr}(t)$ is the at-risk indicator (1 until `s` invades `r`,
+0 thereafter), $d_{sr}$ is the (log) distance, $f$ is the smooth shape
+$\sin(-d/1.5)$, and $h_{sr}(t)$ is an endogenous "neighbour pressure"
+term that grows whenever a country related to `s` has recently invaded
+`r`.
+
+For this short example we use just the distance term and a
+half-life-decayed reciprocity proxy as the endogenous neighbour
+pressure, then turn `risk = "remove"` on so each dyad fires at most
+once.
+
+```{r simulate}
+true_dist_effect <- sin(-dist_log / 1.5)
+
+cc <- simulate_relational_events(
+  n_events            = 600,
+  senders             = states,
+  receivers           = states,
+  contribution_logits = true_dist_effect,
+  baseline_rate       = 1,
+  allow_loops         = FALSE,
+  n_controls          = 1,
+  endogenous_stats    = "reciprocity_exp_decay",
+  endogenous_effects  = c(reciprocity_exp_decay = 0.4),
+  half_life           = 2,
+  risk                = "remove"
+)
+nrow(cc)
+head(cc)
+```
+
+`risk = "remove"` guarantees the realized dyads are all distinct:
+
+```{r unique-check}
+events_only <- cc[cc$event == 1L, ]
+nrow(events_only)
+any(duplicated(paste(events_only$sender, events_only$receiver)))
+```
+
+## Recovering the drivers
+
+Attach the log-distance for every (sender, receiver) pair in the
+case-control table, then fit a conditional logistic model via GAM on
+the within-stratum differences.
+
+```{r recovery, fig.alt = "recovered smooth distance effect"}
+get_dist <- function(s, r) {
+  dist_log[cbind(match(s, states), match(r, states))]
+}
+cc$dist_val <- mapply(get_dist, cc$sender, cc$receiver)
+
+cases    <- cc[cc$event == 1L, ]
+controls <- cc[cc$event == 0L, ]
+cases    <- cases[order(cases$stratum), ]
+controls <- controls[order(controls$stratum), ]
+
+fit_df <- data.frame(
+  y          = 1,
+  delta_dist = cases$dist_val - controls$dist_val,
+  delta_r    = cases$reciprocity_exp_decay - controls$reciprocity_exp_decay
+)
+
+if (requireNamespace("mgcv", quietly = TRUE)) {
+  library(mgcv)
+  fit <- gam(y ~ s(delta_dist) + delta_r - 1, family = binomial, data = fit_df)
+  summary(fit)
+
+  x_grid <- seq(min(fit_df$delta_dist), max(fit_df$delta_dist), length.out = 200)
+  pred   <- predict(fit,
+                    newdata = data.frame(delta_dist = x_grid, delta_r = 0),
+                    type = "link")
+  plot(x_grid, pred, type = "l", lwd = 2,
+       xlab = expression(Delta ~ "log-distance"),
+       ylab = "estimated effect",
+       main = "GAM smooth for distance (event - control)")
+  abline(h = 0, lty = 2, col = "grey60")
+}
+```
+
+The smooth recovers the underlying $\sin(-d/1.5)$ pattern, and the
+linear coefficient on `delta_r` should be close to the true 0.4 used in
+the simulation.
+
+## Where to go from here
+
+- Real data: replace `dist_matrix` with a country-by-country distance
+  table and the simulated event log with a curated invasion record.
+- Additional covariates: trade flows or climatic similarity enter via
+  `contribution_logits` or sender/receiver covariates.
+- Time-varying global covariates (policy regimes, seasonality) attach
+  through `global_covariates` / `global_effects`.
+- For large state spaces or high invasion rates, switch to the
+  approximate `method = "tau_leap"` simulator with a small `tau` to
+  cut wall-clock cost; the `risk = "remove"` rule is honoured under
+  both algorithms.


### PR DESCRIPTION
Implements three of the gaps identified in the handwritten REM-meeting notes (sample-non-events / About-Time paper / species-invasion application): time-decayed reciprocity in the simulator, a one-shot-dyad risk rule, and an applied vignette demonstrating both.

## What changed

### 1. `reciprocity_exp_decay` endogenous stat (HIGH value)

The `endogenous_stats` argument now accepts `\"reciprocity_exp_decay\"` in addition to `reciprocity_count` and `reciprocity_binary`. A past reverse-dyad event at time $t_k$ contributes $\\exp(-(t - t_k)\\,\\log 2 / T)$ to the stat value at time $t$, matching the post-hoc `compute_endogenous_features()` definition exactly. The new `half_life` argument supplies $T$ and is required whenever the stat is in use.

Implementation: the state matrix is decayed multiplicatively (cell-wise) whenever the clock advances, via an `apply_exp_decay()` closure. The Gillespie path snapshots the decayed state at each event time; the tau-leap path applies decay at the start of each step (all events in the step share that snapshot). Rates use piecewise-constant approximation on inter-event intervals — same approximation as the count/binary stats.

### 2. `risk = c(\"standard\", \"remove\")` rule (HIGH value)

The default is `\"standard\"` (unchanged behaviour). Under `risk = \"remove\"` the simulator drops a dyad from the risk set after it fires, mimicking one-shot processes (species invasions, first citations). Two implementation details worth flagging:

- The Gillespie path now recomputes weights at every step whenever `risk == \"remove\"`, not only when endogenous_stats is active. Without this, removed dyads silently kept firing.
- The tau-leap path uses Bernoulli with $p = 1 - \\exp(-\\lambda\\tau)$ instead of Poisson for per-dyad counts under `\"remove\"`, so a dyad cannot fire more than once per step.
- When the pool of admissible dyads is exhausted, the simulator stops gracefully and returns the events accumulated so far (previously it would error with \"No admissible dyads with positive intensity\").

### 3. Species-invasion vignette

`vignettes/species-invasion.Rmd` is a self-contained walk-through that:

- Uses the package's `dist_matrix` data (56 US states as a stand-in country universe).
- Builds a synthetic invasion log driven by a smooth `sin(-d/1.5)` distance effect plus a decayed neighbour-pressure term (`reciprocity_exp_decay` with $T = 2$).
- Runs the simulator with `risk = \"remove\"` so each dyad fires at most once, with `n_controls = 1` for partial-likelihood ready output.
- Recovers both drivers via a GAM with `s(delta_dist) + delta_r` on the case-control table.

Listed in `_pkgdown.yml` under articles. Knits cleanly against the installed dev version.

## Tests

New file `tests/testthat/test-decay-and-remove.R` (54 cases):

- Hand-verified exp-decay weighted sum row-by-row (zero-coefficient regression)
- `half_life` validation (missing, non-positive, infinite)
- Composition: exp-decay + count in same call, exp-decay <= count invariant
- GAM recovery of true beta = 0.8 on case-control output
- `risk = \"remove\"` produces unique dyads (Gillespie)
- Graceful termination when admissible pool is exhausted
- Case-control composition under remove (no within-stratum overlap event/control)
- `risk = \"remove\"` under tau-leap also unique
- Full composition (exp-decay + remove + case-control)

`devtools::test()`: **357 PASS, 0 FAIL** (was 303).
`R CMD check --no-manual`: **0 errors, 0 warnings, 4 notes** (unchanged set).

## Files

- `R/simulate_events.R` — new `half_life` and `risk` arguments, validation, `apply_exp_decay()` closure, decay snapshot in both Gillespie and tau-leap paths, Bernoulli sampling under tau-leap + remove, graceful pool-exhaustion termination.
- `man/simulate_relational_events.Rd` — regenerated.
- `README.md` — feature bullet updated to mention `reciprocity_exp_decay`, `risk = \"remove\"`.
- `_pkgdown.yml` — adds the new vignette to the articles section.
- `tests/testthat/test-decay-and-remove.R` — new.
- `vignettes/species-invasion.Rmd` — new.