### PR TITLE
Add recency to endogenous_stats; relax one-mode constraint for non-reciprocity stats

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -35,9 +35,12 @@
 #'   the intensity of the next event depends on the realized history. Supported
 #'   values: \code{"reciprocity_count"} (number of past reverse-dyad events),
 #'   \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-#'   least once), and \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
-#'   events with exponential half-life decay; requires \code{half_life}).
-#'   Defaults to \code{NULL} for a memoryless process.
+#'   least once), \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
+#'   events with exponential half-life decay; requires \code{half_life}), and
+#'   \code{"recency"} (elapsed time on the same ordered dyad:
+#'   \eqn{t - t_{\text{last}}(s,r)}, defaulting to
+#'   \eqn{t - \text{start\_time}} for dyads that have never fired). Defaults
+#'   to \code{NULL} for a memoryless process.
 #' @param endogenous_effects Numeric vector of linear coefficients for
 #'   \code{endogenous_stats}. May be named (names must match
 #'   \code{endogenous_stats}) or unnamed (positionally matched). Required when
@@ -238,7 +241,10 @@ simulate_relational_events <- function(
   }
 
   supported_endogenous <- c("reciprocity_count", "reciprocity_binary",
-                            "reciprocity_exp_decay")
+                            "reciprocity_exp_decay", "recency")
+  # `recency` is a per-dyad stat with no reverse-dyad semantics, so it works
+  # for bipartite settings too. Only the reciprocity_* family requires the
+  # one-mode constraint enforced below.
   endogenous_active <- !is.null(endogenous_stats) && length(endogenous_stats) > 0
   if (endogenous_active) {
     endogenous_stats <- as.character(endogenous_stats)
@@ -286,17 +292,23 @@ simulate_relational_events <- function(
     stop("Both sender and receiver sets must be non-empty.")
   }
 
-  if (endogenous_active) {
-    # The current endogenous state machinery maintains a single state matrix
-    # indexed by (sender, receiver) and updates the *reverse* dyad after each
-    # event. That update assumes a shared actor universe: senders and
-    # receivers must be the same set in the same order. Without this
-    # restriction the post-event update writes to the wrong cell on
-    # rectangular (bipartite / two-mode) cases.
+  reciprocity_stats <- c("reciprocity_count", "reciprocity_binary",
+                         "reciprocity_exp_decay")
+  needs_one_mode <- endogenous_active &&
+    any(endogenous_stats %in% reciprocity_stats)
+  if (needs_one_mode) {
+    # The reciprocity_* stats maintain a state matrix indexed by
+    # (sender, receiver) and update the *reverse* dyad after each event. That
+    # update assumes a shared actor universe: senders and receivers must be the
+    # same set in the same order. Without this restriction the post-event
+    # update writes to the wrong cell on rectangular (bipartite / two-mode)
+    # cases. `recency` is per-dyad and works for any S/R, so it does not
+    # trigger this check.
     if (S != R || !identical(senders, receivers)) {
-      stop("endogenous_stats currently requires senders and receivers to be ",
-           "the same character vector in the same order (one-mode networks). ",
-           "Bipartite / two-mode support is on the roadmap.")
+      stop("reciprocity_* endogenous stats currently require senders and ",
+           "receivers to be the same character vector in the same order ",
+           "(one-mode networks). Bipartite / two-mode support is on the ",
+           "roadmap.")
     }
   }
 
@@ -360,7 +372,15 @@ simulate_relational_events <- function(
   endo_state <- list()
   if (endogenous_active) {
     for (st in endogenous_stats) {
-      endo_state[[st]] <- matrix(0, nrow = S, ncol = R)
+      if (st == "recency") {
+        # State cell holds the time of the last event on dyad (s, r);
+        # initialised to start_time so the "elapsed time since last event"
+        # stat is zero for every dyad at t = start_time and grows from
+        # there.
+        endo_state[[st]] <- matrix(start_time, nrow = S, ncol = R)
+      } else {
+        endo_state[[st]] <- matrix(0, nrow = S, ncol = R)
+      }
     }
   }
 
@@ -393,7 +413,12 @@ simulate_relational_events <- function(
     }
     es <- matrix(0, nrow = S, ncol = R)
     for (st in endogenous_stats) {
-      es <- es + endogenous_effects[[st]] * endo_state[[st]]
+      stat_value <- if (st == "recency") {
+        current_time - endo_state[[st]]
+      } else {
+        endo_state[[st]]
+      }
+      es <- es + endogenous_effects[[st]] * stat_value
     }
     es
   }
@@ -523,7 +548,11 @@ simulate_relational_events <- function(
 
           if (endogenous_active) {
             for (st in endogenous_stats) {
-              event_stat_vals[event_counter, st] <- state_snapshot[[st]][s_idx, r_idx]
+              event_stat_vals[event_counter, st] <- if (st == "recency") {
+                ev_times[k] - state_snapshot[[st]][s_idx, r_idx]
+              } else {
+                state_snapshot[[st]][s_idx, r_idx]
+              }
             }
           }
 
@@ -553,8 +582,12 @@ simulate_relational_events <- function(
             if (endogenous_active) {
               ctrl_rows <- ctrl_start_idx:ctrl_end_idx
               for (st in endogenous_stats) {
-                control_stat_vals[ctrl_rows, st] <-
-                  state_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
+                cell_vals <- state_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
+                control_stat_vals[ctrl_rows, st] <- if (st == "recency") {
+                  ev_times[k] - cell_vals
+                } else {
+                  cell_vals
+                }
               }
             }
             if (global_active) {
@@ -580,6 +613,8 @@ simulate_relational_events <- function(
                   endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
                 } else if (st == "reciprocity_binary") {
                   endo_state[[st]][r_k, s_k] <- 1
+                } else if (st == "recency") {
+                  endo_state[[st]][s_k, r_k] <- ev_times[k]
                 }
               }
             }
@@ -673,7 +708,11 @@ simulate_relational_events <- function(
 
     if (endogenous_active) {
       for (st in endogenous_stats) {
-        event_stat_vals[event_counter, st] <- endo_state[[st]][s_idx, r_idx]
+        event_stat_vals[event_counter, st] <- if (st == "recency") {
+          current_time - endo_state[[st]][s_idx, r_idx]
+        } else {
+          endo_state[[st]][s_idx, r_idx]
+        }
       }
     }
 
@@ -710,8 +749,12 @@ simulate_relational_events <- function(
       if (endogenous_active) {
         ctrl_rows <- ctrl_start_idx:ctrl_end_idx
         for (st in endogenous_stats) {
-          control_stat_vals[ctrl_rows, st] <-
-            endo_state[[st]][cbind(c_s_idxs, c_r_idxs)]
+          cell_vals <- endo_state[[st]][cbind(c_s_idxs, c_r_idxs)]
+          control_stat_vals[ctrl_rows, st] <- if (st == "recency") {
+            current_time - cell_vals
+          } else {
+            cell_vals
+          }
         }
       }
 
@@ -726,14 +769,15 @@ simulate_relational_events <- function(
 
     if (endogenous_active) {
       # Update state matrices using the realized event (s_idx -> r_idx).
-      # The reciprocity stat at candidate dyad (s, r) counts past events
-      # (r -> s); on event (s_idx, r_idx), that contributes to future
-      # reciprocity at dyad (r_idx, s_idx).
+      # reciprocity_* stats update the *reverse* dyad (r_idx, s_idx).
+      # recency updates the *same* dyad (s_idx, r_idx) with the event time.
       for (st in endogenous_stats) {
         if (st == "reciprocity_count" || st == "reciprocity_exp_decay") {
           endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
         } else if (st == "reciprocity_binary") {
           endo_state[[st]][r_idx, s_idx] <- 1
+        } else if (st == "recency") {
+          endo_state[[st]][s_idx, r_idx] <- current_time
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ simulation-based REM studies:
   and an approximate time-driven tau-leap (`method = "tau_leap", tau = ...`) —
   with optional controls for partial likelihood, endogenous mechanisms
   (`reciprocity_count`, `reciprocity_binary`, half-life-decayed
-  `reciprocity_exp_decay`) whose state updates between events, time-varying
-  global covariates via a boundary-aware scheme (weekday/weekend rate
-  switches, policy regimes, …), and a `risk = "remove"` rule for one-shot
-  processes such as species invasions or first-citation events.
+  `reciprocity_exp_decay`, and per-dyad `recency`) whose state updates
+  between events, time-varying global covariates via a boundary-aware
+  scheme (weekday/weekend rate switches, policy regimes, …), and a
+  `risk = "remove"` rule for one-shot processes such as species invasions
+  or first-citation events. `recency` also works in bipartite / two-mode
+  settings; the `reciprocity_*` family still requires one-mode networks.
 - **Non-event sampling.** `sample_non_events()` constructs nested case-control
   tables with appearance, citation, and remove risk-set rules.
 - **Inference-ready design matrices.** Simulations or sampled logs can be fed to

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -72,9 +72,12 @@ include in the rate. Each entry updates a state matrix after every event so
 the intensity of the next event depends on the realized history. Supported
 values: \code{"reciprocity_count"} (number of past reverse-dyad events),
 \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-least once), and \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
-events with exponential half-life decay; requires \code{half_life}).
-Defaults to \code{NULL} for a memoryless process.}
+least once), \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
+events with exponential half-life decay; requires \code{half_life}), and
+\code{"recency"} (elapsed time on the same ordered dyad:
+\eqn{t - t_{\text{last}}(s,r)}, defaulting to
+\eqn{t - \text{start\_time}} for dyads that have never fired). Defaults
+to \code{NULL} for a memoryless process.}
 
 \item{endogenous_effects}{Numeric vector of linear coefficients for
 \code{endogenous_stats}. May be named (names must match

--- a/tests/testthat/test-recency.R
+++ b/tests/testthat/test-recency.R
@@ -1,0 +1,132 @@
+# test-recency.R
+# Coverage for the "recency" endogenous stat in simulate_relational_events().
+
+test_that("recency column matches t - t_last on the same ordered dyad", {
+  set.seed(1)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 3,
+    endogenous_stats = "recency",
+    endogenous_effects = 0   # zero coefficient -> column is pure observable
+  )
+  expect_true("recency" %in% names(ev))
+  # Hand-compute: recency at row i = t_i - t_last(s_i, r_i), or t_i - 0
+  # (start_time default) if dyad has never fired.
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    same_mask <- prior$sender == ev$sender[i] & prior$receiver == ev$receiver[i]
+    if (any(same_mask)) {
+      expected <- ev$time[i] - max(prior$time[same_mask])
+    } else {
+      expected <- ev$time[i]   # start_time defaulted to 0
+    }
+    expect_equal(ev$recency[i], expected, tolerance = 1e-9,
+                 info = paste("row", i))
+  }
+})
+
+test_that("recency uses start_time as the never-seen default", {
+  set.seed(7)
+  ev <- simulate_relational_events(
+    n_events = 5,
+    senders = LETTERS[1:3], receivers = LETTERS[1:3],
+    baseline_rate = 5,
+    start_time = 10,
+    endogenous_stats = "recency", endogenous_effects = 0
+  )
+  # First event on its dyad: recency = t - 10.
+  expect_equal(ev$recency[1], ev$time[1] - 10, tolerance = 1e-9)
+})
+
+test_that("recency works in a bipartite (non-square) setting", {
+  set.seed(3)
+  # senders and receivers are disjoint sets of different sizes; reciprocity_*
+  # would have errored, recency must not.
+  ev <- simulate_relational_events(
+    n_events = 12,
+    senders = c("alice", "bob"),
+    receivers = c("u", "v", "w"),
+    baseline_rate = 1,
+    endogenous_stats = "recency",
+    endogenous_effects = 0.5
+  )
+  expect_true("recency" %in% names(ev))
+  expect_true(all(ev$recency >= 0))
+  expect_equal(nrow(ev), 12L)
+})
+
+test_that("reciprocity_* still errors on a bipartite setting", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "reciprocity_count",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+})
+
+test_that("recency composes with reciprocity_count in the same call", {
+  set.seed(11)
+  cc <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:3], receivers = LETTERS[1:3],
+    baseline_rate = 1, n_controls = 1,
+    endogenous_stats = c("recency", "reciprocity_count"),
+    endogenous_effects = c(recency = 0, reciprocity_count = 0)
+  )
+  expect_true(all(c("recency", "reciprocity_count") %in% names(cc)))
+  expect_true(all(cc$recency >= 0))
+  expect_true(all(cc$reciprocity_count >= 0))
+})
+
+test_that("tau-leap path produces the same recency semantics", {
+  set.seed(42)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 2,
+    endogenous_stats = "recency", endogenous_effects = 0,
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true("recency" %in% names(ev))
+  # Each row's recency must be a non-negative observable quantity. We do not
+  # row-by-row match against history because tau-leap's snapshot semantics
+  # use the start-of-step state, which can deviate from exact event-time
+  # state when multiple events fall in the same step.
+  expect_true(all(ev$recency >= 0))
+})
+
+test_that("negative recency effect concentrates events on freshly-fired dyads", {
+  # With a negative coefficient on recency, the rate of dyad (s, r) decays
+  # as more time passes without it firing -- events should cluster on
+  # dyads that have just fired (small recency). Test as a coarse sign
+  # check: mean recency at events < mean for the control population.
+  # Effect kept mild so the rate matrix does not collapse below the
+  # n_controls + 1 admissible-dyad floor.
+  skip_on_cran()
+  set.seed(2026)
+  cc <- simulate_relational_events(
+    n_events = 600,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 2,
+    n_controls = 1,
+    endogenous_stats = "recency",
+    endogenous_effects = -0.8
+  )
+  mean_events   <- mean(cc$recency[cc$event == 1L])
+  mean_controls <- mean(cc$recency[cc$event == 0L])
+  expect_lt(mean_events, mean_controls)
+})
+
+test_that("recency requires an endogenous_effects entry just like other stats", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5, senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      endogenous_stats = "recency"
+    ),
+    "endogenous_effects must be supplied"
+  )
+})


### PR DESCRIPTION
Adds the **recency** endogenous statistic to the simulator and **relaxes the one-mode constraint** so it only fires for stats that genuinely need it (the `reciprocity_*` family). This is the next item from the gap list in the handwritten REM notes (page 5: \"reciprocity\" vs \"Ruta Rec.\" vs \"eventnet\" — recency belongs to the eventnet/degree family).

## What changed

### 1. `recency` endogenous stat

`endogenous_stats` now accepts `\"recency\"`. The stat value at dyad $(s, r)$ at time $t$ is the elapsed time since the last event on $(s, r)$:

$$\\text{recency}_{sr}(t) = t - t_{\\text{last}}(s, r),$$

with a default of $t - \\text{start\\_time}$ for dyads that have not fired yet. This matches the post-hoc semantics in `compute_endogenous_features()` (where the never-seen case returns `NA`; the simulator must produce a numeric value, so it falls back to elapsed-since-start).

Implementation:
- State is a matrix of last-event times, initialised to `start_time` so the initial recency is zero everywhere.
- The score contribution is `endogenous_effects[[\"recency\"]] * (current_time - endo_state[[\"recency\"]])`.
- After event $(s_i, r_i)$ fires, `endo_state[[\"recency\"]][s_i, r_i]` is set to the event time — the **same** dyad, not the reverse one.

### 2. One-mode constraint relaxed

Before this PR, any `endogenous_stats` triggered the check that `senders` and `receivers` are the same character vector in the same order, because the reciprocity state update writes to the reverse dyad and would mis-index in rectangular cases. `recency` does not touch the reverse dyad, so it works fine on bipartite / two-mode networks.

The check is now scoped to `reciprocity_count`, `reciprocity_binary`, and `reciprocity_exp_decay` only. Mixed configurations (e.g. `c(\"recency\", \"reciprocity_count\")`) still require one-mode because at least one of them is a reciprocity stat.

## API example

```r
# one-mode
ev <- simulate_relational_events(
  n_events           = 200,
  senders            = LETTERS[1:5],
  receivers          = LETTERS[1:5],
  baseline_rate      = 1,
  endogenous_stats   = \"recency\",
  endogenous_effects = -0.5     # negative = habit / clustering on fresh dyads
)

# bipartite -- works now, errored before
bp <- simulate_relational_events(
  n_events           = 100,
  senders            = c(\"alice\", \"bob\"),
  receivers          = c(\"u\", \"v\", \"w\"),
  endogenous_stats   = \"recency\",
  endogenous_effects = 0.3
)
```

## Tests

New `tests/testthat/test-recency.R` (43 cases):

- Row-by-row exact match: recency column = $t - t_{\\text{last}}$ on the same dyad, or $t - \\text{start\\_time}$ if never fired
- `start_time = 10` default for never-seen
- Bipartite (2x3) setting runs without error
- `reciprocity_count` on bipartite still errors (regression for the relaxed check)
- Composition with `reciprocity_count` in the same call
- Tau-leap path produces non-negative recency values
- Sign check: negative effect concentrates events on freshly-fired dyads
- Missing-effects validation

`devtools::test()`: **400 PASS, 0 FAIL** (was 357).
`R CMD check --no-manual`: **0 errors, 0 warnings, 4 notes** (unchanged set).

## Files

- `R/simulate_events.R`: new `recency` entry in supported_endogenous, special-case state init, score-matrix branch, Gillespie + tau-leap snapshot branches, state-update branch. One-mode check narrowed to the `reciprocity_*` family.
- `man/simulate_relational_events.Rd`: regenerated.
- `README.md`: feature bullet updated.
- `tests/testthat/test-recency.R`: new.

## Where this lands in the roadmap

| Stat | In simulator? | Post-hoc only? |
|---|---|---|
| `reciprocity_count` | ✓ | ✓ |
| `reciprocity_binary` | ✓ | ✓ |
| `reciprocity_exp_decay` | ✓ | ✓ |
| `reciprocity_time_recent`, `reciprocity_time_first` | — | ✓ |
| `sender_outdegree`, `receiver_indegree` | — | ✓ |
| **`recency`** | ✓ (this PR) | ✓ |
| `transitivity_*`, `cyclic_*`, `sending_balance_*`, `receiving_balance_*` | — | ✓ |

Next obvious step is transitivity / cyclic / balance — they share a common adjacency-matrix state so a single follow-up PR can land all three families. Saved for a separate PR.