### PR TITLE
Add transitivity, cyclic, sending-balance, receiving-balance endogenous stats

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -33,14 +33,31 @@
 #' @param endogenous_stats Optional character vector of endogenous mechanisms to
 #'   include in the rate. Each entry updates a state matrix after every event so
 #'   the intensity of the next event depends on the realized history. Supported
-#'   values: \code{"reciprocity_count"} (number of past reverse-dyad events),
-#'   \code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-#'   least once), \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
-#'   events with exponential half-life decay; requires \code{half_life}), and
-#'   \code{"recency"} (elapsed time on the same ordered dyad:
-#'   \eqn{t - t_{\text{last}}(s,r)}, defaulting to
-#'   \eqn{t - \text{start\_time}} for dyads that have never fired). Defaults
-#'   to \code{NULL} for a memoryless process.
+#'   values:
+#'   \itemize{
+#'     \item \code{"reciprocity_count"} — number of past reverse-dyad events.
+#'     \item \code{"reciprocity_binary"} — 1 if the reverse dyad has fired at
+#'       least once, 0 otherwise.
+#'     \item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
+#'       with exponential half-life decay (requires \code{half_life}).
+#'     \item \code{"recency"} — elapsed time on the same ordered dyad
+#'       \eqn{t - t_{\text{last}}(s,r)}, defaulting to
+#'       \eqn{t - \text{start\_time}} for dyads that have never fired.
+#'     \item \code{"transitivity_count"} / \code{"transitivity_binary"} —
+#'       number of intermediaries \eqn{k} (or indicator that at least one
+#'       exists) for which both \eqn{(s,k)} and \eqn{(k,r)} have fired.
+#'     \item \code{"cyclic_count"} / \code{"cyclic_binary"} — number of
+#'       intermediaries \eqn{k} (or indicator) for which both \eqn{(r,k)} and
+#'       \eqn{(k,s)} have fired (cyclic two-path closing \eqn{s \to r}).
+#'     \item \code{"sending_balance_count"} / \code{"sending_balance_binary"} —
+#'       number of shared targets \eqn{k} (or indicator) where both
+#'       \eqn{(s,k)} and \eqn{(r,k)} have fired.
+#'     \item \code{"receiving_balance_count"} /
+#'       \code{"receiving_balance_binary"} — number of shared sources
+#'       \eqn{k} (or indicator) where both \eqn{(k,s)} and \eqn{(k,r)} have
+#'       fired.
+#'   }
+#'   Defaults to \code{NULL} for a memoryless process.
 #' @param endogenous_effects Numeric vector of linear coefficients for
 #'   \code{endogenous_stats}. May be named (names must match
 #'   \code{endogenous_stats}) or unnamed (positionally matched). Required when
@@ -240,11 +257,16 @@ simulate_relational_events <- function(
     global_log_mult <- as.numeric(global_cov_matrix %*% global_effects)
   }
 
-  supported_endogenous <- c("reciprocity_count", "reciprocity_binary",
-                            "reciprocity_exp_decay", "recency")
-  # `recency` is a per-dyad stat with no reverse-dyad semantics, so it works
-  # for bipartite settings too. Only the reciprocity_* family requires the
-  # one-mode constraint enforced below.
+  reciprocity_stats <- c("reciprocity_count", "reciprocity_binary",
+                         "reciprocity_exp_decay")
+  network_stats <- c("transitivity_count", "transitivity_binary",
+                     "cyclic_count", "cyclic_binary",
+                     "sending_balance_count", "sending_balance_binary",
+                     "receiving_balance_count", "receiving_balance_binary")
+  supported_endogenous <- c(reciprocity_stats, "recency", network_stats)
+  # `recency` is a per-dyad stat with no actor-graph semantics, so it works
+  # for bipartite settings too. The reciprocity_* and network_* families
+  # require a one-mode setting (square actor universe) enforced below.
   endogenous_active <- !is.null(endogenous_stats) && length(endogenous_stats) > 0
   if (endogenous_active) {
     endogenous_stats <- as.character(endogenous_stats)
@@ -292,23 +314,23 @@ simulate_relational_events <- function(
     stop("Both sender and receiver sets must be non-empty.")
   }
 
-  reciprocity_stats <- c("reciprocity_count", "reciprocity_binary",
-                         "reciprocity_exp_decay")
+  one_mode_required_stats <- c(reciprocity_stats, network_stats)
   needs_one_mode <- endogenous_active &&
-    any(endogenous_stats %in% reciprocity_stats)
+    any(endogenous_stats %in% one_mode_required_stats)
   if (needs_one_mode) {
     # The reciprocity_* stats maintain a state matrix indexed by
-    # (sender, receiver) and update the *reverse* dyad after each event. That
-    # update assumes a shared actor universe: senders and receivers must be the
-    # same set in the same order. Without this restriction the post-event
-    # update writes to the wrong cell on rectangular (bipartite / two-mode)
-    # cases. `recency` is per-dyad and works for any S/R, so it does not
-    # trigger this check.
+    # (sender, receiver) and update the *reverse* dyad after each event;
+    # the network_* (transitivity / cyclic / balance) stats use a binary
+    # adjacency matrix and matrix products that only make sense when the
+    # actor universe is the same on both axes. Both families require senders
+    # and receivers to be the same character vector in the same order.
+    # `recency` is per-dyad with no reverse-dyad or path semantics, so it
+    # does not trigger this check.
     if (S != R || !identical(senders, receivers)) {
-      stop("reciprocity_* endogenous stats currently require senders and ",
-           "receivers to be the same character vector in the same order ",
-           "(one-mode networks). Bipartite / two-mode support is on the ",
-           "roadmap.")
+      stop("reciprocity_* and network_* endogenous stats currently require ",
+           "senders and receivers to be the same character vector in the ",
+           "same order (one-mode networks). Bipartite / two-mode support ",
+           "is on the roadmap.")
     }
   }
 
@@ -384,6 +406,16 @@ simulate_relational_events <- function(
     }
   }
 
+  # Shared binary adjacency matrix used by every network_* stat
+  # (transitivity / cyclic / sending_balance / receiving_balance). Only
+  # allocated when at least one such stat is active. The matrix is square
+  # because needs_one_mode is enforced earlier.
+  has_network_stats <- endogenous_active &&
+    any(endogenous_stats %in% network_stats)
+  adj_state <- if (has_network_stats) {
+    matrix(0, nrow = S, ncol = S)
+  } else NULL
+
   has_exp_decay <- endogenous_active &&
     "reciprocity_exp_decay" %in% endogenous_stats
   last_state_time <- start_time
@@ -407,18 +439,49 @@ simulate_relational_events <- function(
     invisible()
   }
 
+  endo_stat_values <- function() {
+    # Returns a named list of S x R stat-value matrices, one per requested
+    # stat, evaluated at the current clock time and state. Used by both
+    # score (linear predictor) and snapshot (output columns). Recomputed
+    # whenever called -- callers should reuse the result within a step.
+    if (!endogenous_active) return(NULL)
+    needs_AA  <- any(endogenous_stats %in% c("transitivity_count",
+                                              "transitivity_binary",
+                                              "cyclic_count",
+                                              "cyclic_binary"))
+    needs_AAt <- any(endogenous_stats %in% c("sending_balance_count",
+                                              "sending_balance_binary"))
+    needs_AtA <- any(endogenous_stats %in% c("receiving_balance_count",
+                                              "receiving_balance_binary"))
+    AA  <- if (needs_AA)  adj_state %*% adj_state         else NULL
+    AAt <- if (needs_AAt) adj_state %*% t(adj_state)       else NULL
+    AtA <- if (needs_AtA) t(adj_state) %*% adj_state       else NULL
+    vals <- list()
+    for (st in endogenous_stats) {
+      vals[[st]] <- switch(st,
+        "recency"                   = current_time - endo_state[[st]],
+        "transitivity_count"        = AA,
+        "transitivity_binary"       = (AA > 0) * 1.0,
+        "cyclic_count"              = t(AA),
+        "cyclic_binary"             = (t(AA) > 0) * 1.0,
+        "sending_balance_count"     = AAt,
+        "sending_balance_binary"    = (AAt > 0) * 1.0,
+        "receiving_balance_count"   = AtA,
+        "receiving_balance_binary"  = (AtA > 0) * 1.0,
+        endo_state[[st]]
+      )
+    }
+    vals
+  }
+
   endo_score_matrix <- function() {
     if (!endogenous_active) {
       return(NULL)
     }
+    vals <- endo_stat_values()
     es <- matrix(0, nrow = S, ncol = R)
     for (st in endogenous_stats) {
-      stat_value <- if (st == "recency") {
-        current_time - endo_state[[st]]
-      } else {
-        endo_state[[st]]
-      }
-      es <- es + endogenous_effects[[st]] * stat_value
+      es <- es + endogenous_effects[[st]] * vals[[st]]
     }
     es
   }
@@ -526,13 +589,15 @@ simulate_relational_events <- function(
         ev_dyads <- ev_dyads[ord]
         ev_times <- ev_times[ord]
 
-        # Snapshot endogenous state at start of step. All events in the
-        # step are scored against this snapshot; the live state is updated
-        # once at the end of the step.
-        state_snapshot <- if (endogenous_active) {
-          snap <- list()
-          for (st in endogenous_stats) snap[[st]] <- endo_state[[st]]
-          snap
+        # Snapshot stat-value matrices at the start of the step. All events
+        # in the step are scored against this snapshot; the live state is
+        # updated once at the end of the step. For `recency` (which depends
+        # on the clock), we keep the raw last-seen-time matrix and subtract
+        # the per-event time when emitting the row.
+        step_vals_snapshot <- if (endogenous_active) endo_stat_values() else NULL
+        recency_state_snapshot <- if (endogenous_active &&
+                                       "recency" %in% endogenous_stats) {
+          endo_state[["recency"]]
         } else NULL
 
         for (k in seq_len(n_in_step)) {
@@ -549,9 +614,9 @@ simulate_relational_events <- function(
           if (endogenous_active) {
             for (st in endogenous_stats) {
               event_stat_vals[event_counter, st] <- if (st == "recency") {
-                ev_times[k] - state_snapshot[[st]][s_idx, r_idx]
+                ev_times[k] - recency_state_snapshot[s_idx, r_idx]
               } else {
-                state_snapshot[[st]][s_idx, r_idx]
+                step_vals_snapshot[[st]][s_idx, r_idx]
               }
             }
           }
@@ -582,11 +647,10 @@ simulate_relational_events <- function(
             if (endogenous_active) {
               ctrl_rows <- ctrl_start_idx:ctrl_end_idx
               for (st in endogenous_stats) {
-                cell_vals <- state_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
                 control_stat_vals[ctrl_rows, st] <- if (st == "recency") {
-                  ev_times[k] - cell_vals
+                  ev_times[k] - recency_state_snapshot[cbind(c_s_idxs, c_r_idxs)]
                 } else {
-                  cell_vals
+                  step_vals_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
                 }
               }
             }
@@ -616,6 +680,9 @@ simulate_relational_events <- function(
                 } else if (st == "recency") {
                   endo_state[[st]][s_k, r_k] <- ev_times[k]
                 }
+              }
+              if (has_network_stats) {
+                adj_state[s_k, r_k] <- 1
               }
             }
             if (risk == "remove") {
@@ -705,14 +772,14 @@ simulate_relational_events <- function(
     # so the value carried on the output row reflects the time elapsed
     # since the previous event.
     apply_exp_decay()
+    # Compute the full stat-value matrices once per event so the same
+    # values are reused for both the event row and any control rows
+    # below.
+    step_vals <- if (endogenous_active) endo_stat_values() else NULL
 
     if (endogenous_active) {
       for (st in endogenous_stats) {
-        event_stat_vals[event_counter, st] <- if (st == "recency") {
-          current_time - endo_state[[st]][s_idx, r_idx]
-        } else {
-          endo_state[[st]][s_idx, r_idx]
-        }
+        event_stat_vals[event_counter, st] <- step_vals[[st]][s_idx, r_idx]
       }
     }
 
@@ -749,12 +816,8 @@ simulate_relational_events <- function(
       if (endogenous_active) {
         ctrl_rows <- ctrl_start_idx:ctrl_end_idx
         for (st in endogenous_stats) {
-          cell_vals <- endo_state[[st]][cbind(c_s_idxs, c_r_idxs)]
-          control_stat_vals[ctrl_rows, st] <- if (st == "recency") {
-            current_time - cell_vals
-          } else {
-            cell_vals
-          }
+          control_stat_vals[ctrl_rows, st] <-
+            step_vals[[st]][cbind(c_s_idxs, c_r_idxs)]
         }
       }
 
@@ -771,6 +834,7 @@ simulate_relational_events <- function(
       # Update state matrices using the realized event (s_idx -> r_idx).
       # reciprocity_* stats update the *reverse* dyad (r_idx, s_idx).
       # recency updates the *same* dyad (s_idx, r_idx) with the event time.
+      # network_* stats share the binary adjacency adj_state, updated below.
       for (st in endogenous_stats) {
         if (st == "reciprocity_count" || st == "reciprocity_exp_decay") {
           endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
@@ -779,6 +843,9 @@ simulate_relational_events <- function(
         } else if (st == "recency") {
           endo_state[[st]][s_idx, r_idx] <- current_time
         }
+      }
+      if (has_network_stats) {
+        adj_state[s_idx, r_idx] <- 1
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ simulation-based REM studies:
 - **Relational event simulation.** `simulate_relational_events()` runs
   two simulation algorithms — the default exact Gillespie (`method = "gillespie"`)
   and an approximate time-driven tau-leap (`method = "tau_leap", tau = ...`) —
-  with optional controls for partial likelihood, endogenous mechanisms
-  (`reciprocity_count`, `reciprocity_binary`, half-life-decayed
-  `reciprocity_exp_decay`, and per-dyad `recency`) whose state updates
-  between events, time-varying global covariates via a boundary-aware
-  scheme (weekday/weekend rate switches, policy regimes, …), and a
+  with optional controls for partial likelihood, a growing endogenous
+  catalog (reciprocity: `reciprocity_count`, `reciprocity_binary`,
+  half-life-decayed `reciprocity_exp_decay`; degree-style: per-dyad
+  `recency`; two-path: `transitivity_count`/`_binary`, `cyclic_count`/`_binary`;
+  shared-target / shared-source: `sending_balance_count`/`_binary`,
+  `receiving_balance_count`/`_binary`) whose state updates between events,
+  time-varying global covariates via a boundary-aware scheme
+  (weekday/weekend rate switches, policy regimes, …), and a
   `risk = "remove"` rule for one-shot processes such as species invasions
-  or first-citation events. `recency` also works in bipartite / two-mode
-  settings; the `reciprocity_*` family still requires one-mode networks.
+  or first-citation events. `recency` works in bipartite / two-mode
+  settings; the reciprocity and network (transitivity / cyclic / balance)
+  families currently require one-mode networks.
 - **Non-event sampling.** `sample_non_events()` constructs nested case-control
   tables with appearance, citation, and remove risk-set rules.
 - **Inference-ready design matrices.** Simulations or sampled logs can be fed to

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -70,14 +70,31 @@ regression / GAM modeling. Defaults to 0.}
 \item{endogenous_stats}{Optional character vector of endogenous mechanisms to
 include in the rate. Each entry updates a state matrix after every event so
 the intensity of the next event depends on the realized history. Supported
-values: \code{"reciprocity_count"} (number of past reverse-dyad events),
-\code{"reciprocity_binary"} (indicator that the reverse dyad has fired at
-least once), \code{"reciprocity_exp_decay"} (sum of past reverse-dyad
-events with exponential half-life decay; requires \code{half_life}), and
-\code{"recency"} (elapsed time on the same ordered dyad:
+values:
+\itemize{
+\item \code{"reciprocity_count"} — number of past reverse-dyad events.
+\item \code{"reciprocity_binary"} — 1 if the reverse dyad has fired at
+least once, 0 otherwise.
+\item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
+with exponential half-life decay (requires \code{half_life}).
+\item \code{"recency"} — elapsed time on the same ordered dyad
 \eqn{t - t_{\text{last}}(s,r)}, defaulting to
-\eqn{t - \text{start\_time}} for dyads that have never fired). Defaults
-to \code{NULL} for a memoryless process.}
+\eqn{t - \text{start\_time}} for dyads that have never fired.
+\item \code{"transitivity_count"} / \code{"transitivity_binary"} —
+number of intermediaries \eqn{k} (or indicator that at least one
+exists) for which both \eqn{(s,k)} and \eqn{(k,r)} have fired.
+\item \code{"cyclic_count"} / \code{"cyclic_binary"} — number of
+intermediaries \eqn{k} (or indicator) for which both \eqn{(r,k)} and
+\eqn{(k,s)} have fired (cyclic two-path closing \eqn{s \to r}).
+\item \code{"sending_balance_count"} / \code{"sending_balance_binary"} —
+number of shared targets \eqn{k} (or indicator) where both
+\eqn{(s,k)} and \eqn{(r,k)} have fired.
+\item \code{"receiving_balance_count"} /
+\code{"receiving_balance_binary"} — number of shared sources
+\eqn{k} (or indicator) where both \eqn{(k,s)} and \eqn{(k,r)} have
+fired.
+}
+Defaults to \code{NULL} for a memoryless process.}
 
 \item{endogenous_effects}{Numeric vector of linear coefficients for
 \code{endogenous_stats}. May be named (names must match

--- a/tests/testthat/test-network-stats.R
+++ b/tests/testthat/test-network-stats.R
@@ -1,0 +1,209 @@
+# test-network-stats.R
+# Coverage for the transitivity_*, cyclic_*, sending_balance_*,
+# receiving_balance_* endogenous stats.
+
+reverse_adj_at <- function(ev, time_now) {
+  # Build the binary "ever-fired" adjacency from rows of `ev` strictly
+  # before time_now. Returns an actor-by-actor matrix indexed by character
+  # labels.
+  actors <- sort(unique(c(ev$sender, ev$receiver)))
+  A <- matrix(0L, length(actors), length(actors),
+              dimnames = list(actors, actors))
+  prior <- ev[ev$time < time_now, , drop = FALSE]
+  for (i in seq_len(nrow(prior))) {
+    A[prior$sender[i], prior$receiver[i]] <- 1L
+  }
+  A
+}
+
+test_that("transitivity_count matches the (A %*% A) entry hand-derivation", {
+  set.seed(11)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "transitivity_count",
+    endogenous_effects = 0
+  )
+  expect_true("transitivity_count" %in% names(ev))
+  for (i in seq_len(nrow(ev))) {
+    A <- reverse_adj_at(ev, ev$time[i])
+    expected <- sum(A[ev$sender[i], ] * A[, ev$receiver[i]])
+    expect_equal(ev$transitivity_count[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("transitivity_binary equals as.numeric(transitivity_count > 0)", {
+  set.seed(12)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_binary", "transitivity_count"),
+    endogenous_effects = c(transitivity_binary = 0, transitivity_count = 0)
+  )
+  expect_equal(ev$transitivity_binary,
+               as.numeric(ev$transitivity_count > 0))
+})
+
+test_that("cyclic_count at (s, r) equals transitivity at (r, s) for the same history", {
+  set.seed(13)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("cyclic_count", "transitivity_count"),
+    endogenous_effects = c(cyclic_count = 0, transitivity_count = 0)
+  )
+  for (i in seq_len(nrow(ev))) {
+    A <- reverse_adj_at(ev, ev$time[i])
+    expected_cyc <- sum(A[ev$receiver[i], ] * A[, ev$sender[i]])
+    expect_equal(ev$cyclic_count[i], expected_cyc,
+                 info = paste("row", i))
+  }
+})
+
+test_that("sending_balance_count is sum_k A[s,k] * A[r,k]", {
+  set.seed(14)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "sending_balance_count",
+    endogenous_effects = 0
+  )
+  for (i in seq_len(nrow(ev))) {
+    A <- reverse_adj_at(ev, ev$time[i])
+    expected <- sum(A[ev$sender[i], ] * A[ev$receiver[i], ])
+    expect_equal(ev$sending_balance_count[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("receiving_balance_count is sum_k A[k,s] * A[k,r]", {
+  set.seed(15)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "receiving_balance_count",
+    endogenous_effects = 0
+  )
+  for (i in seq_len(nrow(ev))) {
+    A <- reverse_adj_at(ev, ev$time[i])
+    expected <- sum(A[, ev$sender[i]] * A[, ev$receiver[i]])
+    expect_equal(ev$receiving_balance_count[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("all 4 binary stats match as.numeric(count > 0)", {
+  set.seed(16)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_binary", "transitivity_count",
+                         "cyclic_binary", "cyclic_count",
+                         "sending_balance_binary", "sending_balance_count",
+                         "receiving_balance_binary", "receiving_balance_count"),
+    endogenous_effects = setNames(
+      rep(0, 8),
+      c("transitivity_binary", "transitivity_count",
+        "cyclic_binary", "cyclic_count",
+        "sending_balance_binary", "sending_balance_count",
+        "receiving_balance_binary", "receiving_balance_count")
+    )
+  )
+  expect_equal(ev$transitivity_binary,
+               as.numeric(ev$transitivity_count > 0))
+  expect_equal(ev$cyclic_binary,
+               as.numeric(ev$cyclic_count > 0))
+  expect_equal(ev$sending_balance_binary,
+               as.numeric(ev$sending_balance_count > 0))
+  expect_equal(ev$receiving_balance_binary,
+               as.numeric(ev$receiving_balance_count > 0))
+})
+
+test_that("transitivity error on bipartite settings (one-mode required)", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "transitivity_count",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "sending_balance_count",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+})
+
+test_that("recency + transitivity_count compose in the same call", {
+  set.seed(17)
+  ev <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("recency", "transitivity_count"),
+    endogenous_effects = c(recency = 0, transitivity_count = 0)
+  )
+  expect_true(all(c("recency", "transitivity_count") %in% names(ev)))
+  expect_true(all(ev$recency >= 0))
+  expect_true(all(ev$transitivity_count >= 0))
+})
+
+test_that("positive transitivity_count effect is recoverable via GAM on case-control output", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  set.seed(2026)
+  true_beta <- 0.4
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "transitivity_count",
+    endogenous_effects = true_beta
+  )
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+  fit_df <- data.frame(
+    one     = 1,
+    delta_t = cases$transitivity_count - controls$transitivity_count
+  )
+  fit <- gam(one ~ delta_t - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.15 && est < 0.7,
+              info = sprintf("estimated transitivity effect = %.3f", est))
+})
+
+test_that("tau-leap produces the same network-stat semantics under matched seed", {
+  # Tau-leap uses a start-of-step snapshot for stats; values should still be
+  # non-negative integers and the binary should match count > 0 when both
+  # are requested.
+  set.seed(42)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("transitivity_binary", "transitivity_count"),
+    endogenous_effects = c(transitivity_binary = 0, transitivity_count = 0),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_equal(ev$transitivity_binary,
+               as.numeric(ev$transitivity_count > 0))
+  expect_true(all(ev$transitivity_count >= 0))
+})


### PR DESCRIPTION
Adds the **two-path** (transitivity, cyclic) and **shared-neighbour** (sending balance, receiving balance) endogenous statistic families to the simulator, finishing the basic catalog that has been available post-hoc via `compute_endogenous_features()`.

## What changed

Eight new values accepted in `endogenous_stats`:

| Stat | Definition |
|---|---|
| `transitivity_count` / `_binary` | Number of intermediaries $k$ (or indicator $\\geq 1$) with both $s \\to k$ and $k \\to r$ already fired. |
| `cyclic_count` / `_binary` | Number of intermediaries $k$ with both $r \\to k$ and $k \\to s$ already fired (cyclic two-path closing $s \\to r$). |
| `sending_balance_count` / `_binary` | Number of shared targets $k$ with both $s \\to k$ and $r \\to k$ already fired. |
| `receiving_balance_count` / `_binary` | Number of shared sources $k$ with both $k \\to s$ and $k \\to r$ already fired. |

All four families share a single $S \\times S$ binary adjacency matrix `adj_state` that records \"this ordered dyad has ever fired\". The four product matrices ($A \\cdot A$, $A \\cdot A^\\top$, $A^\\top \\cdot A$, and the transpose of $A \\cdot A$ for the cyclic stat) are computed lazily — only when at least one stat in the corresponding bucket is requested.

The score helper was refactored into a stat-value-matrix builder `endo_stat_values()` returning a named list of per-stat $S \\times R$ matrices. Both `endo_score_matrix()` and the snapshot blocks (Gillespie event + control, tau-leap event + control) now use this unified list — replacing the previous fan-out of per-stat `if/else` branches and keeping the snapshot code constant-size as the catalog grows.

The one-mode constraint (`senders` must equal `receivers` in the same order) is extended to cover the network family because the underlying matrix products only make sense on a single actor universe. `recency` is still the only endogenous stat that works on bipartite settings.

## API example

```r
cc <- simulate_relational_events(
  n_events            = 1500,
  senders             = LETTERS[1:8],
  receivers           = LETTERS[1:8],
  baseline_rate       = 1,
  n_controls          = 1,
  endogenous_stats    = c(\"transitivity_count\", \"recency\"),
  endogenous_effects  = c(transitivity_count = 0.4, recency = -0.3)
)
# cc now has columns transitivity_count and recency for both events and controls.
```

## Tests

New `tests/testthat/test-network-stats.R` (119 cases) covers:

- Row-by-row hand-derived expected values against a reverse-built adjacency from each event's history for `transitivity_count`, `cyclic_count`, `sending_balance_count`, `receiving_balance_count`.
- The `binary == as.numeric(count > 0)` identity for all four families.
- The cross-family identity `cyclic_count(s, r) == transitivity_count(r, s)` for the same history.
- Composition with `recency` in a single call.
- One-mode constraint error on bipartite settings.
- Tau-leap path produces consistent values.
- Single-replicate GAM recovery of $\\beta = 0.4$ on `transitivity_count` from case-control output.

`devtools::test()`: **519 PASS, 0 FAIL** (was 400).
`R CMD check --no-manual`: **0 errors, 0 warnings, 4 notes** (unchanged set).

## Files

- `R/simulate_events.R`: 8 new `supported_endogenous` entries, shared `adj_state` matrix, new `endo_stat_values()` helper, refactored score + snapshot to consume it, one-mode constraint extended to network stats, `adj_state` update in both Gillespie and tau-leap state-update blocks.
- `man/simulate_relational_events.Rd`: regenerated, with the full catalog now formatted as an itemize.
- `README.md`: feature bullet expanded.
- `tests/testthat/test-network-stats.R`: new.

## Where this lands in the roadmap

After this PR, the simulator's endogenous catalog matches the basic (non-time, non-decay) entries of the post-hoc `compute_endogenous_features()`:

| Stat | In simulator? | Post-hoc only? |
|---|---|---|
| `reciprocity_count` / `_binary` / `_exp_decay` | ✓ | ✓ |
| `recency` | ✓ | ✓ |
| `transitivity_count` / `_binary` | ✓ | ✓ |
| `cyclic_count` / `_binary` | ✓ | ✓ |
| `sending_balance_count` / `_binary` | ✓ | ✓ |
| `receiving_balance_count` / `_binary` | ✓ | ✓ |
| `*_ordered` variants (require event-time tracking, not just adjacency) | — | ✓ |
| `*_exp_decay` for transitivity/cyclic | — | ✓ |
| `*_time_recent`, `*_time_first` | — | ✓ |
| `sender_outdegree`, `receiver_indegree` | — | ✓ |

Next obvious wins are the **timing variants** (`*_time_recent` and `*_exp_decay` for transitivity / cyclic) which would let users replicate Juozaitienė & Wit (2025) entirely from the simulator. Held back for a separate PR to keep this one focused.