### PR TITLE
Add reciprocity_time_recent and reciprocity_time_first endogenous stats

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -40,6 +40,13 @@
 #'       least once, 0 otherwise.
 #'     \item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
 #'       with exponential half-life decay (requires \code{half_life}).
+#'     \item \code{"reciprocity_time_recent"} — elapsed time since the most
+#'       recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
+#'       \code{0} for dyads whose reverse has never fired (rather than the
+#'       post-hoc \code{NA}, so the rate computation stays numeric).
+#'     \item \code{"reciprocity_time_first"} — elapsed time since the
+#'       \emph{first} reverse-dyad event \eqn{t - t_{\text{first}}(r,s)};
+#'       same \code{0}-for-never-seen convention.
 #'     \item \code{"recency"} — elapsed time on the same ordered dyad
 #'       \eqn{t - t_{\text{last}}(s,r)}, defaulting to
 #'       \eqn{t - \text{start\_time}} for dyads that have never fired.
@@ -262,7 +269,8 @@ simulate_relational_events <- function(
   }
 
   reciprocity_stats <- c("reciprocity_count", "reciprocity_binary",
-                         "reciprocity_exp_decay")
+                         "reciprocity_exp_decay",
+                         "reciprocity_time_recent", "reciprocity_time_first")
   network_stats <- c("transitivity_count", "transitivity_binary",
                      "cyclic_count", "cyclic_binary",
                      "sending_balance_count", "sending_balance_binary",
@@ -407,6 +415,12 @@ simulate_relational_events <- function(
         # stat is zero for every dyad at t = start_time and grows from
         # there.
         endo_state[[st]] <- matrix(start_time, nrow = S, ncol = R)
+      } else if (st %in% c("reciprocity_time_recent",
+                            "reciprocity_time_first")) {
+        # NA marks "the reverse dyad has never fired". Replaced with 0 in
+        # the score / output matrices so the rate computation stays
+        # numeric (see endo_stat_values()).
+        endo_state[[st]] <- matrix(NA_real_, nrow = S, ncol = R)
       } else {
         endo_state[[st]] <- matrix(0, nrow = S, ncol = R)
       }
@@ -475,10 +489,19 @@ simulate_relational_events <- function(
     # Broadcasting via matrix(v, S, R) (column-fill) replicates the
     # length-S sender vector across columns; matrix(v, S, R, byrow = TRUE)
     # replicates the length-R receiver vector across rows.
+    # Helper: time-elapsed stat with NA -> 0 replacement so the score stays
+    # numeric for never-seen cells. Used by the reciprocity_time_* family.
+    time_elapsed_or_zero <- function(state_mat) {
+      v <- current_time - state_mat
+      v[is.na(v)] <- 0
+      v
+    }
     vals <- list()
     for (st in endogenous_stats) {
       vals[[st]] <- switch(st,
         "recency"                   = current_time - endo_state[[st]],
+        "reciprocity_time_recent"   = time_elapsed_or_zero(endo_state[[st]]),
+        "reciprocity_time_first"    = time_elapsed_or_zero(endo_state[[st]]),
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -613,14 +636,37 @@ simulate_relational_events <- function(
 
         # Snapshot stat-value matrices at the start of the step. All events
         # in the step are scored against this snapshot; the live state is
-        # updated once at the end of the step. For `recency` (which depends
-        # on the clock), we keep the raw last-seen-time matrix and subtract
-        # the per-event time when emitting the row.
+        # updated once at the end of the step. For time-dependent stats
+        # (recency, reciprocity_time_recent, reciprocity_time_first) we
+        # capture the raw state and subtract the per-event time when
+        # emitting each row, so the value carried is correct for that
+        # specific event time within the step.
         step_vals_snapshot <- if (endogenous_active) endo_stat_values() else NULL
-        recency_state_snapshot <- if (endogenous_active &&
-                                       "recency" %in% endogenous_stats) {
-          endo_state[["recency"]]
-        } else NULL
+        time_state_snapshots <- if (endogenous_active) {
+          snap <- list()
+          for (ts in c("recency", "reciprocity_time_recent",
+                       "reciprocity_time_first")) {
+            if (ts %in% endogenous_stats) {
+              snap[[ts]] <- endo_state[[ts]]
+            }
+          }
+          snap
+        } else list()
+
+        # Per-event time-dependent stat value, single-cell variant.
+        time_stat_at <- function(st, s, r, t) {
+          v <- t - time_state_snapshots[[st]][s, r]
+          if (st == "recency") v else if (is.na(v)) 0 else v
+        }
+        # Per-event time-dependent stat value, vectorized (rectangular
+        # selection) variant.
+        time_stat_at_v <- function(st, ss, rs, t) {
+          v <- t - time_state_snapshots[[st]][cbind(ss, rs)]
+          if (st == "recency") return(v)
+          v[is.na(v)] <- 0
+          v
+        }
+        time_stats_active <- names(time_state_snapshots)
 
         for (k in seq_len(n_in_step)) {
           if (event_counter >= n_events) break
@@ -635,8 +681,8 @@ simulate_relational_events <- function(
 
           if (endogenous_active) {
             for (st in endogenous_stats) {
-              event_stat_vals[event_counter, st] <- if (st == "recency") {
-                ev_times[k] - recency_state_snapshot[s_idx, r_idx]
+              event_stat_vals[event_counter, st] <- if (st %in% time_stats_active) {
+                time_stat_at(st, s_idx, r_idx, ev_times[k])
               } else {
                 step_vals_snapshot[[st]][s_idx, r_idx]
               }
@@ -669,8 +715,8 @@ simulate_relational_events <- function(
             if (endogenous_active) {
               ctrl_rows <- ctrl_start_idx:ctrl_end_idx
               for (st in endogenous_stats) {
-                control_stat_vals[ctrl_rows, st] <- if (st == "recency") {
-                  ev_times[k] - recency_state_snapshot[cbind(c_s_idxs, c_r_idxs)]
+                control_stat_vals[ctrl_rows, st] <- if (st %in% time_stats_active) {
+                  time_stat_at_v(st, c_s_idxs, c_r_idxs, ev_times[k])
                 } else {
                   step_vals_snapshot[[st]][cbind(c_s_idxs, c_r_idxs)]
                 }
@@ -699,6 +745,12 @@ simulate_relational_events <- function(
                   endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
                 } else if (st == "reciprocity_binary") {
                   endo_state[[st]][r_k, s_k] <- 1
+                } else if (st == "reciprocity_time_recent") {
+                  endo_state[[st]][r_k, s_k] <- ev_times[k]
+                } else if (st == "reciprocity_time_first") {
+                  if (is.na(endo_state[[st]][r_k, s_k])) {
+                    endo_state[[st]][r_k, s_k] <- ev_times[k]
+                  }
                 } else if (st == "recency") {
                   endo_state[[st]][s_k, r_k] <- ev_times[k]
                 }
@@ -865,6 +917,12 @@ simulate_relational_events <- function(
           endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
         } else if (st == "reciprocity_binary") {
           endo_state[[st]][r_idx, s_idx] <- 1
+        } else if (st == "reciprocity_time_recent") {
+          endo_state[[st]][r_idx, s_idx] <- current_time
+        } else if (st == "reciprocity_time_first") {
+          if (is.na(endo_state[[st]][r_idx, s_idx])) {
+            endo_state[[st]][r_idx, s_idx] <- current_time
+          }
         } else if (st == "recency") {
           endo_state[[st]][s_idx, r_idx] <- current_time
         }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ simulation-based REM studies:
   and an approximate time-driven tau-leap (`method = "tau_leap", tau = ...`) —
   with optional controls for partial likelihood, a growing endogenous
   catalog (reciprocity: `reciprocity_count`, `reciprocity_binary`,
-  half-life-decayed `reciprocity_exp_decay`; per-actor degree: `sender_outdegree`,
+  half-life-decayed `reciprocity_exp_decay`, `reciprocity_time_recent`,
+  `reciprocity_time_first`; per-actor degree: `sender_outdegree`,
   `receiver_indegree`; per-dyad `recency`; two-path: `transitivity_count`/`_binary`,
   `cyclic_count`/`_binary`; shared-target / shared-source:
   `sending_balance_count`/`_binary`, `receiving_balance_count`/`_binary`)

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -77,6 +77,13 @@ values:
 least once, 0 otherwise.
 \item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
 with exponential half-life decay (requires \code{half_life}).
+\item \code{"reciprocity_time_recent"} — elapsed time since the most
+recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
+\code{0} for dyads whose reverse has never fired (rather than the
+post-hoc \code{NA}, so the rate computation stays numeric).
+\item \code{"reciprocity_time_first"} — elapsed time since the
+\emph{first} reverse-dyad event \eqn{t - t_{\text{first}}(r,s)};
+same \code{0}-for-never-seen convention.
 \item \code{"recency"} — elapsed time on the same ordered dyad
 \eqn{t - t_{\text{last}}(s,r)}, defaulting to
 \eqn{t - \text{start\_time}} for dyads that have never fired.

--- a/tests/testthat/test-reciprocity-timing.R
+++ b/tests/testthat/test-reciprocity-timing.R
@@ -1,0 +1,176 @@
+# test-reciprocity-timing.R
+# Coverage for reciprocity_time_recent and reciprocity_time_first.
+
+test_that("reciprocity_time_recent equals t - max(time of prior reverse events)", {
+  set.seed(11)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 3,
+    endogenous_stats = "reciprocity_time_recent",
+    endogenous_effects = 0
+  )
+  expect_true("reciprocity_time_recent" %in% names(ev))
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    reverse_times <- prior$time[prior$sender == ev$receiver[i] &
+                                  prior$receiver == ev$sender[i]]
+    expected <- if (length(reverse_times)) {
+      ev$time[i] - max(reverse_times)
+    } else {
+      0
+    }
+    expect_equal(ev$reciprocity_time_recent[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("reciprocity_time_first equals t - min(time of prior reverse events)", {
+  set.seed(12)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 3,
+    endogenous_stats = "reciprocity_time_first",
+    endogenous_effects = 0
+  )
+  expect_true("reciprocity_time_first" %in% names(ev))
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    reverse_times <- prior$time[prior$sender == ev$receiver[i] &
+                                  prior$receiver == ev$sender[i]]
+    expected <- if (length(reverse_times)) {
+      ev$time[i] - min(reverse_times)
+    } else {
+      0
+    }
+    expect_equal(ev$reciprocity_time_first[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("time_first >= time_recent on every row (first event was at least as early)", {
+  set.seed(13)
+  ev <- simulate_relational_events(
+    n_events = 40,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_time_first", "reciprocity_time_recent"),
+    endogenous_effects = c(reciprocity_time_first = 0,
+                            reciprocity_time_recent = 0)
+  )
+  expect_true(all(ev$reciprocity_time_first >= ev$reciprocity_time_recent))
+})
+
+test_that("both timing stats are 0 on the first occurrence of a dyad direction (never-seen reverse)", {
+  set.seed(14)
+  ev <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_time_recent", "reciprocity_time_first"),
+    endogenous_effects = c(reciprocity_time_recent = 0,
+                            reciprocity_time_first = 0)
+  )
+  # For each row, check whether the reverse dyad has fired before it. If
+  # not, both stats must be zero.
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    reverse_seen <- any(prior$sender == ev$receiver[i] &
+                          prior$receiver == ev$sender[i])
+    if (!reverse_seen) {
+      expect_equal(ev$reciprocity_time_recent[i], 0, info = paste("row", i))
+      expect_equal(ev$reciprocity_time_first[i],  0, info = paste("row", i))
+    }
+  }
+})
+
+test_that("timing stats error on bipartite settings (one-mode required)", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "reciprocity_time_recent",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "reciprocity_time_first",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+})
+
+test_that("timing stats compose with other reciprocity stats in the same call", {
+  set.seed(15)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 2,
+    endogenous_stats = c("reciprocity_count", "reciprocity_time_recent",
+                         "reciprocity_time_first"),
+    endogenous_effects = c(reciprocity_count = 0,
+                            reciprocity_time_recent = 0,
+                            reciprocity_time_first = 0)
+  )
+  expect_true(all(c("reciprocity_count", "reciprocity_time_recent",
+                    "reciprocity_time_first") %in% names(ev)))
+  # When reciprocity_count is 0 (reverse never fired) the timing stats
+  # must also be 0.
+  zero_recent <- ev$reciprocity_count == 0
+  expect_true(all(ev$reciprocity_time_recent[zero_recent] == 0))
+  expect_true(all(ev$reciprocity_time_first[zero_recent]  == 0))
+})
+
+test_that("timing stats work under tau-leap (start-of-step approximation)", {
+  set.seed(16)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 2,
+    endogenous_stats = c("reciprocity_time_recent", "reciprocity_time_first"),
+    endogenous_effects = c(reciprocity_time_recent = 0,
+                            reciprocity_time_first = 0),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true(all(ev$reciprocity_time_recent >= 0))
+  expect_true(all(ev$reciprocity_time_first  >= 0))
+  expect_true(all(ev$reciprocity_time_first >= ev$reciprocity_time_recent))
+})
+
+test_that("positive coefficient on reciprocity_time_recent is sign-recoverable via GAM", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  # A positive coefficient on time_recent means dyads whose reverse fired
+  # *long ago* fire faster; a negative one means recent-reverse dyads do.
+  # Use a positive true beta and check the sign and magnitude of the
+  # recovered estimate.
+  set.seed(2026)
+  true_beta <- 0.4
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, n_controls = 1,
+    endogenous_stats = "reciprocity_time_recent",
+    endogenous_effects = true_beta
+  )
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+  fit_df <- data.frame(
+    one     = 1,
+    delta_t = cases$reciprocity_time_recent - controls$reciprocity_time_recent
+  )
+  fit <- gam(one ~ delta_t - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.1 && est < 0.75,
+              info = sprintf("estimated time_recent effect = %.3f", est))
+})


### PR DESCRIPTION
Adds the two reciprocity **timing variants** from `compute_endogenous_features()` to the simulator. Scope kept tight: transitivity / cyclic / balance timing stats are a follow-up because they need per-intermediary time tracking (heavier state).

## What changed

| Stat | Definition |
|---|---|
| `reciprocity_time_recent` | $t - t_{\text{recent}}(r, s)$ — elapsed time since the most recent reverse-dyad event. |
| `reciprocity_time_first` | $t - t_{\text{first}}(r, s)$ — elapsed time since the *first* reverse-dyad event. |

Both belong to the `reciprocity_stats` group → one-mode required (same constraint as the existing reciprocity stats).

### Implementation

State: two NA-initialized matrices. On event $(s_i, r_i)$:

- `reciprocity_time_recent[r_i, s_i]` is overwritten with the event time (always; tracks "most recent").
- `reciprocity_time_first[r_i, s_i]` is set only if it is currently NA (preserves the *very first* reverse occurrence).

### NA handling — slight deviation from `compute_endogenous_features()`

`compute_endogenous_features()` returns NA when the reverse dyad has never fired. The simulator instead reports **0** for never-seen cells (via the new `time_elapsed_or_zero()` helper in `endo_stat_values()`). Reason: the score computation needs a numeric value to feed through `exp()`; NA would propagate. The 0 convention is consistent across all "time-elapsed" stats in the simulator (`recency`, `reciprocity_time_*`). Documented in the Rd. Users who want strict NA semantics in their output can post-process by checking `reciprocity_count == 0`.

### Tau-leap snapshot semantics

The tau-leap path captures raw state matrices at the start of each step (now via the unified `time_state_snapshots` list covering `recency`, `reciprocity_time_recent`, and `reciprocity_time_first`) and applies per-event-time substitution per emitted row. Cleaner than the prior recency-only special case.

## API example

```r
cc <- simulate_relational_events(
  n_events           = 1000,
  senders            = LETTERS[1:8],
  receivers          = LETTERS[1:8],
  baseline_rate      = 1, n_controls = 1,
  endogenous_stats   = c(\"reciprocity_count\", \"reciprocity_time_recent\"),
  endogenous_effects = c(reciprocity_count = 0.3, reciprocity_time_recent = -0.2)
)
# Two columns appended; analyse via case-control GAM as usual.
```

## Tests

New `tests/testthat/test-reciprocity-timing.R` (97 cases):

- Row-by-row exact match: `reciprocity_time_recent` = $t - \\max(\\text{prior reverse times})$, `reciprocity_time_first` = $t - \\min(\\text{prior reverse times})$.
- The invariant `time_first >= time_recent` on every row.
- Both stats are 0 on the first occurrence of a dyad direction (never-seen reverse).
- One-mode error on bipartite settings (matches the rest of `reciprocity_*`).
- Composition with `reciprocity_count` in a single call, including the cross-stat check that `reciprocity_count == 0` implies both timing values are 0.
- Tau-leap path produces non-negative values and respects the `time_first >= time_recent` invariant.
- Single-replicate GAM recovery of $\\beta = 0.4$ on `reciprocity_time_recent`.

`devtools::test()`: **864 PASS, 0 FAIL** (was 766).
`R CMD check --no-manual`: **0 errors, 0 warnings, 4 notes** (unchanged set).

## Catalog status after this PR

| Family | Simulator | Post-hoc |
|---|---|---|
| reciprocity (count, binary, exp_decay, **time_recent, time_first**) | ✓ | ✓ |
| recency | ✓ | ✓ |
| sender_outdegree / receiver_indegree | ✓ | ✓ |
| transitivity (count, binary) | ✓ | ✓ |
| cyclic (count, binary) | ✓ | ✓ |
| sending_balance (count, binary) | ✓ | ✓ |
| receiving_balance (count, binary) | ✓ | ✓ |
| `transitivity_time_*`, `cyclic_time_*`, `balance_time_*` | — | ✓ |
| `*_exp_decay` for non-reciprocity | — | ✓ |
| `*_ordered` variants | — | ✓ |

The remaining post-hoc-only entries are the **timing / decay / ordered variants for the network family**, which need heavier per-intermediary state tracking.

## Files

- `R/simulate_events.R`: 2 new `supported_endogenous` entries (in the `reciprocity_stats` group), NA-init for the two new state matrices, `time_elapsed_or_zero()` helper in `endo_stat_values()`, update logic in Gillespie + tau-leap state-update blocks, refactored tau-leap snapshot to use a unified `time_state_snapshots` list.
- `man/simulate_relational_events.Rd`: regenerated.
- `README.md`: feature bullet expanded.
- `tests/testthat/test-reciprocity-timing.R`: new.