### PR TITLE
Add transitivity_time_recent and transitivity_time_first

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -67,6 +67,14 @@
 #'       \code{"receiving_balance_binary"} — number of shared sources
 #'       \eqn{k} (or indicator) where both \eqn{(k,s)} and \eqn{(k,r)} have
 #'       fired.
+#'     \item \code{"transitivity_time_recent"} — elapsed time since the most
+#'       recent two-path \eqn{s \to k \to r} was completed, for any
+#'       intermediary \eqn{k} (definition 7ac of Juozaitienė & Wit, 2024).
+#'       Reports \code{0} for dyads where no two-path has ever existed.
+#'     \item \code{"transitivity_time_first"} — elapsed time since the
+#'       \emph{first} two-path \eqn{s \to k \to r} was completed
+#'       (definition 7bc of Juozaitienė & Wit, 2024). Same
+#'       \code{0}-for-never-seen convention.
 #'   }
 #'   Defaults to \code{NULL} for a memoryless process.
 #' @param endogenous_effects Numeric vector of linear coefficients for
@@ -274,7 +282,8 @@ simulate_relational_events <- function(
   network_stats <- c("transitivity_count", "transitivity_binary",
                      "cyclic_count", "cyclic_binary",
                      "sending_balance_count", "sending_balance_binary",
-                     "receiving_balance_count", "receiving_balance_binary")
+                     "receiving_balance_count", "receiving_balance_binary",
+                     "transitivity_time_recent", "transitivity_time_first")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
                             degree_stats, network_stats)
@@ -416,10 +425,13 @@ simulate_relational_events <- function(
         # there.
         endo_state[[st]] <- matrix(start_time, nrow = S, ncol = R)
       } else if (st %in% c("reciprocity_time_recent",
-                            "reciprocity_time_first")) {
-        # NA marks "the reverse dyad has never fired". Replaced with 0 in
-        # the score / output matrices so the rate computation stays
-        # numeric (see endo_stat_values()).
+                            "reciprocity_time_first",
+                            "transitivity_time_recent",
+                            "transitivity_time_first")) {
+        # NA marks "the relevant past event (reverse dyad, or two-path)
+        # has never happened". Replaced with 0 in the score / output
+        # matrices so the rate computation stays numeric (see
+        # endo_stat_values()).
         endo_state[[st]] <- matrix(NA_real_, nrow = S, ncol = R)
       } else {
         endo_state[[st]] <- matrix(0, nrow = S, ncol = R)
@@ -502,6 +514,8 @@ simulate_relational_events <- function(
         "recency"                   = current_time - endo_state[[st]],
         "reciprocity_time_recent"   = time_elapsed_or_zero(endo_state[[st]]),
         "reciprocity_time_first"    = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_time_recent"  = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_time_first"   = time_elapsed_or_zero(endo_state[[st]]),
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -645,7 +659,9 @@ simulate_relational_events <- function(
         time_state_snapshots <- if (endogenous_active) {
           snap <- list()
           for (ts in c("recency", "reciprocity_time_recent",
-                       "reciprocity_time_first")) {
+                       "reciprocity_time_first",
+                       "transitivity_time_recent",
+                       "transitivity_time_first")) {
             if (ts %in% endogenous_stats) {
               snap[[ts]] <- endo_state[[ts]]
             }
@@ -753,6 +769,32 @@ simulate_relational_events <- function(
                   }
                 } else if (st == "recency") {
                   endo_state[[st]][s_k, r_k] <- ev_times[k]
+                } else if (st == "transitivity_time_recent" ||
+                           st == "transitivity_time_first") {
+                  if (adj_state[s_k, r_k] == 0) {
+                    a_idxs <- which(adj_state[, s_k] == 1)
+                    if (length(a_idxs)) {
+                      if (st == "transitivity_time_recent") {
+                        endo_state[[st]][a_idxs, r_k] <- ev_times[k]
+                      } else {
+                        fresh <- is.na(endo_state[[st]][a_idxs, r_k])
+                        if (any(fresh)) {
+                          endo_state[[st]][a_idxs[fresh], r_k] <- ev_times[k]
+                        }
+                      }
+                    }
+                    b_idxs <- which(adj_state[r_k, ] == 1)
+                    if (length(b_idxs)) {
+                      if (st == "transitivity_time_recent") {
+                        endo_state[[st]][s_k, b_idxs] <- ev_times[k]
+                      } else {
+                        fresh <- is.na(endo_state[[st]][s_k, b_idxs])
+                        if (any(fresh)) {
+                          endo_state[[st]][s_k, b_idxs[fresh]] <- ev_times[k]
+                        }
+                      }
+                    }
+                  }
                 }
               }
               if (has_network_stats) {
@@ -925,6 +967,43 @@ simulate_relational_events <- function(
           }
         } else if (st == "recency") {
           endo_state[[st]][s_idx, r_idx] <- current_time
+        } else if (st == "transitivity_time_recent" ||
+                   st == "transitivity_time_first") {
+          # A two-path s -> k -> r is *formed* at the time the second of
+          # its two legs is first observed. Re-fires of an existing leg
+          # don't form new two-paths. So only sweep when this is the
+          # first occurrence of dyad (s_idx, r_idx).
+          if (adj_state[s_idx, r_idx] == 0) {
+            # As second leg (k = s_idx, r = r_idx): chains a -> s_idx -> r_idx
+            # form now for every a with adj_state[a, s_idx] = 1 that doesn't
+            # already participate in such a chain. The "didn't already
+            # participate" condition is precisely "the first leg fired but
+            # the second leg (s_idx -> r_idx) had not, until now".
+            a_idxs <- which(adj_state[, s_idx] == 1)
+            if (length(a_idxs)) {
+              if (st == "transitivity_time_recent") {
+                endo_state[[st]][a_idxs, r_idx] <- current_time
+              } else {
+                fresh <- is.na(endo_state[[st]][a_idxs, r_idx])
+                if (any(fresh)) {
+                  endo_state[[st]][a_idxs[fresh], r_idx] <- current_time
+                }
+              }
+            }
+            # As first leg (s = s_idx, k = r_idx): chains s_idx -> r_idx -> b
+            # form now for every b with adj_state[r_idx, b] = 1.
+            b_idxs <- which(adj_state[r_idx, ] == 1)
+            if (length(b_idxs)) {
+              if (st == "transitivity_time_recent") {
+                endo_state[[st]][s_idx, b_idxs] <- current_time
+              } else {
+                fresh <- is.na(endo_state[[st]][s_idx, b_idxs])
+                if (any(fresh)) {
+                  endo_state[[st]][s_idx, b_idxs[fresh]] <- current_time
+                }
+              }
+            }
+          }
         }
       }
       if (has_network_stats) {

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -104,6 +104,14 @@ number of shared targets \eqn{k} (or indicator) where both
 \code{"receiving_balance_binary"} — number of shared sources
 \eqn{k} (or indicator) where both \eqn{(k,s)} and \eqn{(k,r)} have
 fired.
+\item \code{"transitivity_time_recent"} — elapsed time since the most
+recent two-path \eqn{s \to k \to r} was completed, for any
+intermediary \eqn{k} (definition 7ac of Juozaitienė & Wit, 2024).
+Reports \code{0} for dyads where no two-path has ever existed.
+\item \code{"transitivity_time_first"} — elapsed time since the
+\emph{first} two-path \eqn{s \to k \to r} was completed
+(definition 7bc of Juozaitienė & Wit, 2024). Same
+\code{0}-for-never-seen convention.
 }
 Defaults to \code{NULL} for a memoryless process.}
 

--- a/tests/testthat/test-transitivity-timing.R
+++ b/tests/testthat/test-transitivity-timing.R
@@ -1,0 +1,183 @@
+# test-transitivity-timing.R
+# Coverage for transitivity_time_recent and transitivity_time_first.
+#
+# Per Juozaitienė & Wit (2024) §2.2.1 these are the t^(7ac) and t^(7bc)
+# definitions: the time elapsed since the most recent / first two-path
+# s -> k -> r was formed for any intermediary k. "Formed" means the
+# later of the two legs (s,k) and (k,r) had been observed.
+
+two_path_times <- function(ev, i) {
+  # For event row i, return the formation times of every two-path
+  # s -> k -> r where s = ev$sender[i], r = ev$receiver[i], computed
+  # from rows strictly before i (the simulator records the value the
+  # dyad had at its event time, *before* this event fires).
+  prior <- ev[seq_len(i - 1L), , drop = FALSE]
+  s <- ev$sender[i]; r <- ev$receiver[i]
+  ks <- unique(c(prior$sender, prior$receiver))
+  out <- numeric(0)
+  for (k in ks) {
+    leg1_times <- prior$time[prior$sender == s & prior$receiver == k]
+    leg2_times <- prior$time[prior$sender == k & prior$receiver == r]
+    if (length(leg1_times) && length(leg2_times)) {
+      out <- c(out, max(min(leg1_times), min(leg2_times)))
+    }
+  }
+  out
+}
+
+test_that("transitivity_time_recent equals t - max(formation time of 2-paths s->k->r)", {
+  set.seed(31)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "transitivity_time_recent",
+    endogenous_effects = 0
+  )
+  expect_true("transitivity_time_recent" %in% names(ev))
+  for (i in seq_len(nrow(ev))) {
+    fts <- two_path_times(ev, i)
+    expected <- if (length(fts)) ev$time[i] - max(fts) else 0
+    expect_equal(ev$transitivity_time_recent[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("transitivity_time_first equals t - min(formation time of 2-paths s->k->r)", {
+  set.seed(32)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "transitivity_time_first",
+    endogenous_effects = 0
+  )
+  expect_true("transitivity_time_first" %in% names(ev))
+  for (i in seq_len(nrow(ev))) {
+    fts <- two_path_times(ev, i)
+    expected <- if (length(fts)) ev$time[i] - min(fts) else 0
+    expect_equal(ev$transitivity_time_first[i], expected,
+                 info = paste("row", i))
+  }
+})
+
+test_that("time_first >= time_recent on every row", {
+  set.seed(33)
+  ev <- simulate_relational_events(
+    n_events = 40,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_time_first", "transitivity_time_recent"),
+    endogenous_effects = c(transitivity_time_first = 0,
+                            transitivity_time_recent = 0)
+  )
+  expect_true(all(ev$transitivity_time_first >= ev$transitivity_time_recent))
+})
+
+test_that("both timing stats are 0 when transitivity_count is 0 (no two-path yet)", {
+  set.seed(34)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count",
+                         "transitivity_time_recent",
+                         "transitivity_time_first"),
+    endogenous_effects = c(transitivity_count = 0,
+                            transitivity_time_recent = 0,
+                            transitivity_time_first = 0)
+  )
+  zero <- ev$transitivity_count == 0
+  expect_true(all(ev$transitivity_time_recent[zero] == 0))
+  expect_true(all(ev$transitivity_time_first[zero]  == 0))
+})
+
+test_that("timing stats error on bipartite settings (one-mode required)", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "transitivity_time_recent",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = c("a", "b"), receivers = c("x", "y", "z"),
+      endogenous_stats = "transitivity_time_first",
+      endogenous_effects = 0.5
+    ),
+    "one-mode"
+  )
+})
+
+test_that("transitivity timing composes with transitivity_count and recency", {
+  set.seed(35)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("transitivity_count", "transitivity_time_recent",
+                         "transitivity_time_first", "recency"),
+    endogenous_effects = c(transitivity_count = 0,
+                            transitivity_time_recent = 0,
+                            transitivity_time_first = 0,
+                            recency = 0)
+  )
+  expect_true(all(c("transitivity_count", "transitivity_time_recent",
+                    "transitivity_time_first", "recency") %in% names(ev)))
+  expect_true(all(ev$transitivity_time_recent >= 0))
+  expect_true(all(ev$transitivity_time_first  >= 0))
+})
+
+test_that("timing stats work under tau-leap", {
+  set.seed(36)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("transitivity_time_recent",
+                         "transitivity_time_first"),
+    endogenous_effects = c(transitivity_time_recent = 0,
+                            transitivity_time_first = 0),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true(all(ev$transitivity_time_recent >= 0))
+  expect_true(all(ev$transitivity_time_first  >= 0))
+  expect_true(all(ev$transitivity_time_first >= ev$transitivity_time_recent))
+})
+
+test_that("positive coefficient on transitivity_time_recent is sign-recoverable", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+
+  # A positive coefficient on time_recent means dyads whose last two-path
+  # formed long ago fire faster; in our (low-rate) baseline, this is
+  # equivalent to: dyads with old two-paths get a boost. Use 1500 events
+  # and case-control with n_controls = 1.
+  set.seed(2026)
+  true_beta <- 0.3
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "transitivity_time_recent",
+    endogenous_effects = true_beta
+  )
+  cases    <- cc[cc$event == 1L, ]
+  controls <- cc[cc$event == 0L, ]
+  cases    <- cases[order(cases$stratum), ]
+  controls <- controls[order(controls$stratum), ]
+  fit_df <- data.frame(
+    one     = 1,
+    delta_t = cases$transitivity_time_recent - controls$transitivity_time_recent
+  )
+  fit <- gam(one ~ delta_t - 1, family = "binomial", data = fit_df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.05 && est < 0.65,
+              info = sprintf("estimated transitivity_time_recent effect = %.3f", est))
+})


### PR DESCRIPTION
## Summary

Adds the two highest-impact endogenous stats from Juozaitienė & Wit (2024, *JRSS-A* 188(4), "It's about time: revisiting reciprocity and triadicity in relational event analysis"):

- `transitivity_time_recent` — definition t^(7ac): elapsed time since the most recent two-path `s → k → r` was formed.
- `transitivity_time_first` — definition t^(7bc): elapsed time since the first such two-path was formed.

The paper's empirical headline (Table 3) selects this temporal family in 4/4 of the studied datasets that show a transitivity effect, beating count-based, binary, and exponentially-decayed alternatives by AIC. Until this PR, `amore` could not generate this functional form.

## Semantics

A two-path `s → k → r` is *formed* at the time its second leg is first observed; re-fires of an already-fired leg do not form new two-paths. The state is updated per-event by sweeping the adjacency matrix (O(S) per event) only when the firing dyad has never fired before. NA in the state matrix marks "no two-path yet" and renders to 0 in score / output.

## Test plan

- [x] `tests/testthat/test-transitivity-timing.R` (8 blocks, 63 assertions): exact equality to a brute-force formation-time reference; ordering (`first >= recent`); zero when `transitivity_count` is 0; bipartite raises; composes with `transitivity_count` and `recency`; works under `tau_leap`; GAM sign-recovery on case-control.
- [x] Full suite: 928 PASS / 0 FAIL.