### PR TITLE
Add ordered transitivity stats to the simulator

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -86,6 +86,18 @@
 #'       \code{"receiving_balance_time_first"} — elapsed time since the
 #'       most recent / first shared-source two-path
 #'       \eqn{k \to s,\ k \to r} was completed.
+#'     \item \code{"transitivity_count_ordered"} /
+#'       \code{"transitivity_binary_ordered"} — number of intermediaries
+#'       \eqn{k} (or indicator) for which an ordered two-path
+#'       \eqn{s \to k} \emph{before} \eqn{k \to r} has been observed
+#'       (definitions \eqn{t^{(4c)}} / \eqn{t^{(2c)}} of
+#'       Juozaitienė & Wit, 2024).
+#'     \item \code{"transitivity_time_recent_ordered"} /
+#'       \code{"transitivity_time_first_ordered"} — elapsed time since
+#'       the most recent / first ordered two-path
+#'       \eqn{s \to k} \emph{before} \eqn{k \to r} was completed
+#'       (definitions \eqn{t^{(8ac)}} / \eqn{t^{(8bc)}} of
+#'       Juozaitienė & Wit, 2024).
 #'   }
 #'   Defaults to \code{NULL} for a memoryless process.
 #' @param endogenous_effects Numeric vector of linear coefficients for
@@ -298,7 +310,15 @@ simulate_relational_events <- function(
                      "cyclic_time_recent", "cyclic_time_first",
                      "sending_balance_time_recent", "sending_balance_time_first",
                      "receiving_balance_time_recent",
-                     "receiving_balance_time_first")
+                     "receiving_balance_time_first",
+                     "transitivity_count_ordered",
+                     "transitivity_binary_ordered",
+                     "transitivity_time_recent_ordered",
+                     "transitivity_time_first_ordered")
+  ordered_stats <- c("transitivity_count_ordered",
+                     "transitivity_binary_ordered",
+                     "transitivity_time_recent_ordered",
+                     "transitivity_time_first_ordered")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
                             degree_stats, network_stats)
@@ -448,7 +468,9 @@ simulate_relational_events <- function(
                             "sending_balance_time_recent",
                             "sending_balance_time_first",
                             "receiving_balance_time_recent",
-                            "receiving_balance_time_first")) {
+                            "receiving_balance_time_first",
+                            "transitivity_time_recent_ordered",
+                            "transitivity_time_first_ordered")) {
         # NA marks "the relevant past event (reverse dyad, or two-path)
         # has never happened". Replaced with 0 in the score / output
         # matrices so the rate computation stays numeric (see
@@ -469,6 +491,26 @@ simulate_relational_events <- function(
   adj_state <- if (has_network_stats) {
     matrix(0, nrow = S, ncol = S)
   } else NULL
+
+  # Ordered transitivity needs per-dyad first / last event timestamps so we
+  # can detect when an event (i, j) is the first (i, j) AFTER a previously
+  # observed (s, i) -- the only situation in which a chronologically
+  # ordered chain s -> i -> j is newly validated.
+  has_ordered_stats <- endogenous_active &&
+    any(endogenous_stats %in% ordered_stats)
+  if (has_ordered_stats) {
+    first_dyad_time <- matrix(NA_real_, nrow = S, ncol = S)
+    last_dyad_time  <- matrix(NA_real_, nrow = S, ncol = S)
+    # Shared count state, fed by every ordered stat (count, binary,
+    # time_recent, time_first) so that the binary version can be
+    # derived from the count even when the count itself isn't
+    # requested by the caller.
+    ord_count_state <- matrix(0L, nrow = S, ncol = S)
+  } else {
+    first_dyad_time <- NULL
+    last_dyad_time  <- NULL
+    ord_count_state <- NULL
+  }
 
   # Per-actor accumulators for the degree_* stats. Length-S sender count
   # vector and length-R receiver count vector, both starting at zero.
@@ -560,6 +602,56 @@ simulate_relational_events <- function(
     M
   }
 
+  # Detects every chronologically ordered chain s -> i -> j that is *newly
+  # validated* by the event (i, j) firing at time `t_now`. A chain
+  # (s, i, j) is newly validated iff
+  #   (a) first_dyad_time[s, i] is set (s -> i happened earlier in the run),
+  #   (b) this (i, j) event is the first (i, j) AFTER first_dyad_time[s, i].
+  # Condition (b) holds when there is no prior (i, j) event, or when the
+  # most recent (i, j) event was earlier than the first (s, i) event.
+  # Returns the integer index vector of senders s whose chain was newly
+  # validated by this event. Callers update ord_count_state and the
+  # time_*_ordered state matrices using this vector.
+  ordered_validation_mask <- function(i, j) {
+    if (!has_ordered_stats) return(integer(0))
+    col_first_si <- first_dyad_time[, i]
+    last_ij_prev <- last_dyad_time[i, j]
+    mask <- !is.na(col_first_si) &
+            (is.na(last_ij_prev) | col_first_si > last_ij_prev)
+    which(mask)
+  }
+
+  # Single helper that performs the full ordered-stat update for an event
+  # (i, j) at time t_now: validates new ordered chains, increments
+  # ord_count_state, refreshes the time_*_ordered state matrices, and
+  # bumps first_dyad_time / last_dyad_time. Called from both the Gillespie
+  # and tau-leap inner loops.
+  apply_ordered_update <- function(i, j, t_now) {
+    if (has_ordered_stats) {
+      validated <- ordered_validation_mask(i, j)
+      if (length(validated)) {
+        ord_count_state[cbind(validated, rep(j, length(validated)))] <<-
+          ord_count_state[cbind(validated, rep(j, length(validated)))] + 1L
+        if (!is.null(endo_state[["transitivity_time_recent_ordered"]])) {
+          endo_state[["transitivity_time_recent_ordered"]][
+            cbind(validated, rep(j, length(validated)))] <<- t_now
+        }
+        if (!is.null(endo_state[["transitivity_time_first_ordered"]])) {
+          M <- endo_state[["transitivity_time_first_ordered"]]
+          idx <- cbind(validated, rep(j, length(validated)))
+          fresh <- is.na(M[idx])
+          if (any(fresh)) M[idx[fresh, , drop = FALSE]] <- t_now
+          endo_state[["transitivity_time_first_ordered"]] <<- M
+        }
+      }
+      # Per-dyad bookkeeping after the validation sweep so the *current*
+      # event doesn't pollute its own predecessor view.
+      if (is.na(first_dyad_time[i, j])) first_dyad_time[i, j] <<- t_now
+      last_dyad_time[i, j] <<- t_now
+    }
+    invisible()
+  }
+
   apply_exp_decay <- function() {
     # Multiplicative decay of the exp-decay state cell-wise to the current
     # clock time. Called when reading or snapshotting state so the value
@@ -619,6 +711,10 @@ simulate_relational_events <- function(
         "sending_balance_time_first"    = time_elapsed_or_zero(endo_state[[st]]),
         "receiving_balance_time_recent" = time_elapsed_or_zero(endo_state[[st]]),
         "receiving_balance_time_first"  = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_count_ordered"      = ord_count_state * 1.0,
+        "transitivity_binary_ordered"     = (ord_count_state > 0) * 1.0,
+        "transitivity_time_recent_ordered"= time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_time_first_ordered" = time_elapsed_or_zero(endo_state[[st]]),
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -769,7 +865,9 @@ simulate_relational_events <- function(
                        "sending_balance_time_recent",
                        "sending_balance_time_first",
                        "receiving_balance_time_recent",
-                       "receiving_balance_time_first")) {
+                       "receiving_balance_time_first",
+                       "transitivity_time_recent_ordered",
+                       "transitivity_time_first_ordered")) {
             if (ts %in% endogenous_stats) {
               snap[[ts]] <- endo_state[[ts]]
             }
@@ -889,6 +987,7 @@ simulate_relational_events <- function(
               if (has_network_stats) {
                 adj_state[s_k, r_k] <- 1
               }
+              apply_ordered_update(s_k, r_k, ev_times[k])
               if (has_outdeg) sender_out_count[s_k]  <- sender_out_count[s_k]  + 1
               if (has_indeg)  receiver_in_count[r_k] <- receiver_in_count[r_k] + 1
             }
@@ -1073,6 +1172,7 @@ simulate_relational_events <- function(
       if (has_network_stats) {
         adj_state[s_idx, r_idx] <- 1
       }
+      apply_ordered_update(s_idx, r_idx, current_time)
       if (has_outdeg) sender_out_count[s_idx]  <- sender_out_count[s_idx]  + 1
       if (has_indeg)  receiver_in_count[r_idx] <- receiver_in_count[r_idx] + 1
     }

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -123,6 +123,18 @@ most recent / first shared-target two-path
 \code{"receiving_balance_time_first"} — elapsed time since the
 most recent / first shared-source two-path
 \eqn{k \to s,\ k \to r} was completed.
+\item \code{"transitivity_count_ordered"} /
+\code{"transitivity_binary_ordered"} — number of intermediaries
+\eqn{k} (or indicator) for which an ordered two-path
+\eqn{s \to k} \emph{before} \eqn{k \to r} has been observed
+(definitions \eqn{t^{(4c)}} / \eqn{t^{(2c)}} of
+Juozaitienė & Wit, 2024).
+\item \code{"transitivity_time_recent_ordered"} /
+\code{"transitivity_time_first_ordered"} — elapsed time since
+the most recent / first ordered two-path
+\eqn{s \to k} \emph{before} \eqn{k \to r} was completed
+(definitions \eqn{t^{(8ac)}} / \eqn{t^{(8bc)}} of
+Juozaitienė & Wit, 2024).
 }
 Defaults to \code{NULL} for a memoryless process.}
 

--- a/tests/testthat/test-ordered-transitivity.R
+++ b/tests/testthat/test-ordered-transitivity.R
@@ -1,0 +1,195 @@
+# test-ordered-transitivity.R
+# Coverage for the four new generative ordered-transitivity stats:
+#   transitivity_count_ordered, transitivity_binary_ordered,
+#   transitivity_time_recent_ordered, transitivity_time_first_ordered.
+#
+# Per Juozaitiene & Wit (2024) eqs 2c / 4c / 8ac / 8bc, an *ordered*
+# two-path s -> k -> r requires the chronological constraint that the
+# first leg (s, k) is observed strictly before the second leg (k, r);
+# unordered variants allow either temporal order.
+
+# Brute-force computation of the set of validated intermediaries `k` and
+# their per-k validation times for an ordered chain s -> k -> r given the
+# prior event log `prior`. Returns a numeric vector (possibly empty) of
+# validation times, one per validated k.
+validated_ordered <- function(prior, s, r, actors) {
+  out <- numeric(0)
+  for (k in actors) {
+    if (k == s || k == r) next
+    leg1 <- prior$time[prior$sender == s & prior$receiver == k]
+    leg2 <- prior$time[prior$sender == k & prior$receiver == r]
+    if (!length(leg1) || !length(leg2)) next
+    # Smallest leg2 time that is strictly after the smallest leg1 time
+    # is the chain's validation time (first time both legs are present
+    # with the required ordering). If no such leg2 exists, the chain
+    # is not ordered-validated.
+    earliest_leg1 <- min(leg1)
+    valid_leg2 <- leg2[leg2 > earliest_leg1]
+    if (length(valid_leg2)) out <- c(out, min(valid_leg2))
+  }
+  out
+}
+
+run_check <- function(seed, n_events = 25, n_actors = 5) {
+  set.seed(seed)
+  ev <- simulate_relational_events(
+    n_events = n_events,
+    senders = LETTERS[1:n_actors], receivers = LETTERS[1:n_actors],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count_ordered",
+                         "transitivity_binary_ordered",
+                         "transitivity_time_recent_ordered",
+                         "transitivity_time_first_ordered"),
+    endogenous_effects = c(transitivity_count_ordered = 0,
+                            transitivity_binary_ordered = 0,
+                            transitivity_time_recent_ordered = 0,
+                            transitivity_time_first_ordered = 0)
+  )
+  actors <- LETTERS[1:n_actors]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    val_times <- validated_ordered(prior, ev$sender[i], ev$receiver[i], actors)
+    exp_count <- length(val_times)
+    exp_binary <- as.numeric(exp_count > 0)
+    exp_recent <- if (exp_count) ev$time[i] - max(val_times) else 0
+    exp_first  <- if (exp_count) ev$time[i] - min(val_times) else 0
+    expect_equal(ev$transitivity_count_ordered[i],  exp_count,  info = paste("row", i))
+    expect_equal(ev$transitivity_binary_ordered[i], exp_binary, info = paste("row", i))
+    expect_equal(ev$transitivity_time_recent_ordered[i], exp_recent,
+                 info = paste("row", i, "recent"))
+    expect_equal(ev$transitivity_time_first_ordered[i],  exp_first,
+                 info = paste("row", i, "first"))
+  }
+  ev
+}
+
+test_that("count / binary / time_recent / time_first match brute-force ordered semantics", {
+  for (sd in c(11, 12, 13)) run_check(sd)
+})
+
+test_that("ordered count is always <= unordered count", {
+  set.seed(21)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count", "transitivity_count_ordered"),
+    endogenous_effects = c(transitivity_count = 0,
+                            transitivity_count_ordered = 0)
+  )
+  expect_true(all(ev$transitivity_count_ordered <= ev$transitivity_count))
+})
+
+test_that("binary_ordered equals (count_ordered > 0) on every row", {
+  set.seed(22)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count_ordered",
+                         "transitivity_binary_ordered"),
+    endogenous_effects = c(transitivity_count_ordered = 0,
+                            transitivity_binary_ordered = 0)
+  )
+  expect_equal(ev$transitivity_binary_ordered,
+               as.numeric(ev$transitivity_count_ordered > 0))
+})
+
+test_that("time_first_ordered >= time_recent_ordered on every row", {
+  set.seed(23)
+  ev <- simulate_relational_events(
+    n_events = 40,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_time_recent_ordered",
+                         "transitivity_time_first_ordered"),
+    endogenous_effects = c(transitivity_time_recent_ordered = 0,
+                            transitivity_time_first_ordered = 0)
+  )
+  expect_true(all(ev$transitivity_time_first_ordered >=
+                   ev$transitivity_time_recent_ordered))
+})
+
+test_that("the time stats are 0 iff count_ordered is 0", {
+  set.seed(24)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count_ordered",
+                         "transitivity_time_recent_ordered",
+                         "transitivity_time_first_ordered"),
+    endogenous_effects = c(transitivity_count_ordered = 0,
+                            transitivity_time_recent_ordered = 0,
+                            transitivity_time_first_ordered = 0)
+  )
+  zero <- ev$transitivity_count_ordered == 0
+  expect_true(all(ev$transitivity_time_recent_ordered[zero] == 0))
+  expect_true(all(ev$transitivity_time_first_ordered[zero]  == 0))
+})
+
+test_that("ordered stats error on bipartite settings (one-mode required)", {
+  for (st in c("transitivity_count_ordered", "transitivity_binary_ordered",
+               "transitivity_time_recent_ordered",
+               "transitivity_time_first_ordered")) {
+    expect_error(
+      simulate_relational_events(
+        n_events = 5,
+        senders = c("a", "b"), receivers = c("x", "y", "z"),
+        endogenous_stats = st,
+        endogenous_effects = 0.5
+      ),
+      "one-mode",
+      info = st
+    )
+  }
+})
+
+test_that("ordered stats work under tau-leap and stay consistent with the count", {
+  set.seed(31)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("transitivity_count_ordered",
+                         "transitivity_binary_ordered",
+                         "transitivity_time_recent_ordered",
+                         "transitivity_time_first_ordered"),
+    endogenous_effects = c(transitivity_count_ordered = 0,
+                            transitivity_binary_ordered = 0,
+                            transitivity_time_recent_ordered = 0,
+                            transitivity_time_first_ordered = 0),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_equal(ev$transitivity_binary_ordered,
+               as.numeric(ev$transitivity_count_ordered > 0))
+  expect_true(all(ev$transitivity_time_first_ordered >=
+                   ev$transitivity_time_recent_ordered))
+})
+
+test_that("a positive coefficient on transitivity_count_ordered is sign-recoverable", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+  set.seed(2026)
+  true_beta <- 0.3
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "transitivity_count_ordered",
+    endogenous_effects = true_beta
+  )
+  cases <- cc[cc$event == 1L, ]; cases <- cases[order(cases$stratum), ]
+  ctrls <- cc[cc$event == 0L, ]; ctrls <- ctrls[order(ctrls$stratum), ]
+  df <- data.frame(
+    one     = rep(1, nrow(cases)),
+    delta_t = cases$transitivity_count_ordered -
+              ctrls$transitivity_count_ordered
+  )
+  fit <- gam(one ~ delta_t - 1, family = "binomial", data = df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.1 && est < 0.65,
+              info = sprintf("estimated count_ordered effect = %.3f", est))
+})


### PR DESCRIPTION
## Summary

Wires four new generative statistics, completing the simulator-side coverage of \citet{juozaitiene2024about}'s transitivity family:

- \`transitivity_count_ordered\`, \`transitivity_binary_ordered\` (paper defs t^(4c), t^(2c)).
- \`transitivity_time_recent_ordered\`, \`transitivity_time_first_ordered\` (paper defs t^(8ac), t^(8bc)).

An *ordered* two-path s → k → r requires the chronological constraint that the first leg (s, k) is observed strictly before the second leg (k, r); the unordered family already in place permits either ordering.

## Implementation

New per-dyad timestamp state: \`first_dyad_time\` and \`last_dyad_time\` (S×S, NA-init) so we can detect when an event (i, j) is the first (i, j) chronologically after a previously observed (s, i) — the only case in which an ordered chain s → i → j is newly validated.

Shared internal \`ord_count_state\` so binary, count, time_recent and time_first all derive from one authoritative state regardless of which subset the caller requested (mirrors how the unordered \`transitivity_count\` and \`_binary\` both read from \`AA\`).

Both inner loops (Gillespie and τ-leap) call the same \`apply_ordered_update()\` helper. The τ-leap path snapshots the new time-* ordered matrices alongside the other timing stats so within-step events are scored against start-of-step state.

## Test plan

- [x] \`tests/testthat/test-ordered-transitivity.R\` (8 blocks, 312 assertions): brute-force-equality vs. an enumerator over all candidate intermediaries (3 separate seeds); ordered ≤ unordered count; binary == (count > 0); first >= recent; zero-when-count-is-zero; bipartite → error; τ-leap consistency; GAM sign-recovery on case-control output.
- [x] Full suite: 1438 PASS / 0 FAIL.
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (all pre-existing).