### PR TITLE
Add transitivity_exp_decay and transitivity_exp_decay_ordered

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -40,6 +40,15 @@
 #'       least once, 0 otherwise.
 #'     \item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
 #'       with exponential half-life decay (requires \code{half_life}).
+#'     \item \code{"transitivity_exp_decay"} —
+#'       \eqn{\sum_{k} e^{-(t - t^{(s,k,r)}_{\text{form}}) \log 2 / T}}
+#'       where \eqn{t^{(s,k,r)}_{\text{form}}} is the formation time of
+#'       two-path \eqn{s \to k \to r} (definition \eqn{t^{(5c)}} of
+#'       Juozaitienė & Wit, 2024). Requires \code{half_life}.
+#'     \item \code{"transitivity_exp_decay_ordered"} — same as
+#'       \code{"transitivity_exp_decay"} but only counts \emph{ordered}
+#'       two-paths (s → k strictly before k → r), definition
+#'       \eqn{t^{(6c)}}.  Requires \code{half_life}.
 #'     \item \code{"reciprocity_time_recent"} — elapsed time since the most
 #'       recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 #'       \code{0} for dyads whose reverse has never fired (rather than the
@@ -105,10 +114,12 @@
 #'   \code{endogenous_stats}) or unnamed (positionally matched). Required when
 #'   \code{endogenous_stats} is supplied.
 #' @param half_life Positive scalar; the half-life \eqn{T} (in time units) used
-#'   by the \code{"reciprocity_exp_decay"} stat. A past reverse-dyad event at
-#'   time \eqn{t_k} contributes \eqn{\exp(-(t - t_k)\,\log 2/T)} to the stat
-#'   value at time \eqn{t}. Required when \code{"reciprocity_exp_decay"} is in
-#'   \code{endogenous_stats}.
+#'   by every \code{*_exp_decay} stat. A past contribution at time \eqn{t_k}
+#'   carries weight \eqn{\exp(-(t - t_k)\,\log 2/T)} into the stat value at
+#'   time \eqn{t}. The same \eqn{T} is shared across all decay stats, matching
+#'   the convention in Juozaitienė & Wit (2024). Required when any of
+#'   \code{"reciprocity_exp_decay"}, \code{"transitivity_exp_decay"},
+#'   \code{"transitivity_exp_decay_ordered"} is in \code{endogenous_stats}.
 #' @param risk Risk-set rule. \code{"standard"} (the default) keeps every dyad
 #'   eligible at every step. \code{"remove"} removes a dyad from the risk set
 #'   as soon as it fires, which mimics one-shot processes such as species
@@ -314,11 +325,16 @@ simulate_relational_events <- function(
                      "transitivity_count_ordered",
                      "transitivity_binary_ordered",
                      "transitivity_time_recent_ordered",
-                     "transitivity_time_first_ordered")
+                     "transitivity_time_first_ordered",
+                     "transitivity_exp_decay",
+                     "transitivity_exp_decay_ordered")
   ordered_stats <- c("transitivity_count_ordered",
                      "transitivity_binary_ordered",
                      "transitivity_time_recent_ordered",
-                     "transitivity_time_first_ordered")
+                     "transitivity_time_first_ordered",
+                     "transitivity_exp_decay_ordered")
+  exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
+                       "transitivity_exp_decay_ordered")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
                             degree_stats, network_stats)
@@ -334,11 +350,13 @@ simulate_relational_events <- function(
       stop("Unsupported endogenous_stats: ", paste(bad, collapse = ", "),
            ". Supported: ", paste(supported_endogenous, collapse = ", "), ".")
     }
-    if ("reciprocity_exp_decay" %in% endogenous_stats) {
+    requires_half_life <- any(endogenous_stats %in% exp_decay_stats)
+    if (requires_half_life) {
       if (is.null(half_life) || length(half_life) != 1 || !is.finite(half_life) ||
           half_life <= 0) {
-        stop("half_life must be a positive finite scalar when ",
-             "\"reciprocity_exp_decay\" is in endogenous_stats.")
+        stop("half_life must be a positive finite scalar when any of ",
+             paste(sprintf("\"%s\"", exp_decay_stats), collapse = ", "),
+             " is in endogenous_stats.")
       }
     }
     if (anyDuplicated(endogenous_stats)) {
@@ -520,7 +538,10 @@ simulate_relational_events <- function(
   receiver_in_count <- if (has_indeg) numeric(R) else NULL
 
   has_exp_decay <- endogenous_active &&
-    "reciprocity_exp_decay" %in% endogenous_stats
+    any(endogenous_stats %in% exp_decay_stats)
+  active_exp_decay_stats <- if (has_exp_decay) {
+    intersect(endogenous_stats, exp_decay_stats)
+  } else character(0)
   last_state_time <- start_time
   if (has_exp_decay) {
     decay_rate <- log(2) / half_life
@@ -630,18 +651,23 @@ simulate_relational_events <- function(
     if (has_ordered_stats) {
       validated <- ordered_validation_mask(i, j)
       if (length(validated)) {
-        ord_count_state[cbind(validated, rep(j, length(validated)))] <<-
-          ord_count_state[cbind(validated, rep(j, length(validated)))] + 1L
+        idx <- cbind(validated, rep(j, length(validated)))
+        ord_count_state[idx] <<- ord_count_state[idx] + 1L
         if (!is.null(endo_state[["transitivity_time_recent_ordered"]])) {
-          endo_state[["transitivity_time_recent_ordered"]][
-            cbind(validated, rep(j, length(validated)))] <<- t_now
+          endo_state[["transitivity_time_recent_ordered"]][idx] <<- t_now
         }
         if (!is.null(endo_state[["transitivity_time_first_ordered"]])) {
           M <- endo_state[["transitivity_time_first_ordered"]]
-          idx <- cbind(validated, rep(j, length(validated)))
           fresh <- is.na(M[idx])
           if (any(fresh)) M[idx[fresh, , drop = FALSE]] <- t_now
           endo_state[["transitivity_time_first_ordered"]] <<- M
+        }
+        if (!is.null(endo_state[["transitivity_exp_decay_ordered"]])) {
+          # Decay state is current as of t_now (apply_exp_decay was called
+          # at the start of this event). Each newly validated chain adds a
+          # fresh contribution of weight 1, which then decays from t_now.
+          endo_state[["transitivity_exp_decay_ordered"]][idx] <<-
+            endo_state[["transitivity_exp_decay_ordered"]][idx] + 1
         }
       }
       # Per-dyad bookkeeping after the validation sweep so the *current*
@@ -653,16 +679,18 @@ simulate_relational_events <- function(
   }
 
   apply_exp_decay <- function() {
-    # Multiplicative decay of the exp-decay state cell-wise to the current
-    # clock time. Called when reading or snapshotting state so the value
-    # carried is correctly attenuated for the time elapsed since the last
-    # update.
+    # Multiplicative decay of every active exp-decay state matrix to the
+    # current clock time. Called when reading or snapshotting state so the
+    # value carried is correctly attenuated for the time elapsed since
+    # the last update. All exp-decay stats share `decay_rate` (= log 2 /
+    # half_life) per the convention of Juozaitienė & Wit (2024).
     if (!has_exp_decay) return(invisible())
     dt_decay <- current_time - last_state_time
     if (dt_decay > 0) {
       decay_factor <- exp(-dt_decay * decay_rate)
-      endo_state[["reciprocity_exp_decay"]] <<-
-        endo_state[["reciprocity_exp_decay"]] * decay_factor
+      for (st in active_exp_decay_stats) {
+        endo_state[[st]] <<- endo_state[[st]] * decay_factor
+      }
       last_state_time <<- current_time
     }
     invisible()
@@ -715,6 +743,8 @@ simulate_relational_events <- function(
         "transitivity_binary_ordered"     = (ord_count_state > 0) * 1.0,
         "transitivity_time_recent_ordered"= time_elapsed_or_zero(endo_state[[st]]),
         "transitivity_time_first_ordered" = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_exp_decay"          = endo_state[[st]],
+        "transitivity_exp_decay_ordered"  = endo_state[[st]],
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -982,6 +1012,13 @@ simulate_relational_events <- function(
                     endo_state[[st]] <- apply_time_writes(
                       endo_state[[st]], writes, ev_times[k], info$first)
                   }
+                } else if (st == "transitivity_exp_decay") {
+                  if (adj_state[s_k, r_k] == 0) {
+                    writes <- two_path_writes("transitivity", s_k, r_k, adj_state)
+                    if (nrow(writes)) {
+                      endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
+                    }
+                  }
                 }
               }
               if (has_network_stats) {
@@ -1166,6 +1203,17 @@ simulate_relational_events <- function(
             writes <- two_path_writes(info$family, s_idx, r_idx, adj_state)
             endo_state[[st]] <- apply_time_writes(
               endo_state[[st]], writes, current_time, info$first)
+          }
+        } else if (st == "transitivity_exp_decay") {
+          # Unordered exp-decay: each newly-formed two-path contributes
+          # +1 (decay state was just attenuated to current_time, so a
+          # fresh contribution of weight exp(0) = 1 is correct). Same
+          # first-fire gate as the timing stats.
+          if (adj_state[s_idx, r_idx] == 0) {
+            writes <- two_path_writes("transitivity", s_idx, r_idx, adj_state)
+            if (nrow(writes)) {
+              endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
+            }
           }
         }
       }

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -77,6 +77,15 @@ values:
 least once, 0 otherwise.
 \item \code{"reciprocity_exp_decay"} — sum of past reverse-dyad events
 with exponential half-life decay (requires \code{half_life}).
+\item \code{"transitivity_exp_decay"} —
+\eqn{\sum_{k} e^{-(t - t^{(s,k,r)}_{\text{form}}) \log 2 / T}}
+where \eqn{t^{(s,k,r)}_{\text{form}}} is the formation time of
+two-path \eqn{s \to k \to r} (definition \eqn{t^{(5c)}} of
+Juozaitienė & Wit, 2024). Requires \code{half_life}.
+\item \code{"transitivity_exp_decay_ordered"} — same as
+\code{"transitivity_exp_decay"} but only counts \emph{ordered}
+two-paths (s → k strictly before k → r), definition
+\eqn{t^{(6c)}}.  Requires \code{half_life}.
 \item \code{"reciprocity_time_recent"} — elapsed time since the most
 recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 \code{0} for dyads whose reverse has never fired (rather than the
@@ -169,10 +178,12 @@ the tau-leap result converges in distribution to the exact Gillespie
 result.}
 
 \item{half_life}{Positive scalar; the half-life \eqn{T} (in time units) used
-by the \code{"reciprocity_exp_decay"} stat. A past reverse-dyad event at
-time \eqn{t_k} contributes \eqn{\exp(-(t - t_k)\,\log 2/T)} to the stat
-value at time \eqn{t}. Required when \code{"reciprocity_exp_decay"} is in
-\code{endogenous_stats}.}
+by every \code{*_exp_decay} stat. A past contribution at time \eqn{t_k}
+carries weight \eqn{\exp(-(t - t_k)\,\log 2/T)} into the stat value at
+time \eqn{t}. The same \eqn{T} is shared across all decay stats, matching
+the convention in Juozaitienė & Wit (2024). Required when any of
+\code{"reciprocity_exp_decay"}, \code{"transitivity_exp_decay"},
+\code{"transitivity_exp_decay_ordered"} is in \code{endogenous_stats}.}
 
 \item{risk}{Risk-set rule. \code{"standard"} (the default) keeps every dyad
 eligible at every step. \code{"remove"} removes a dyad from the risk set

--- a/tests/testthat/test-transitivity-exp-decay.R
+++ b/tests/testthat/test-transitivity-exp-decay.R
@@ -1,0 +1,249 @@
+# test-transitivity-exp-decay.R
+# Coverage for the two new exp-decay transitivity stats:
+#   transitivity_exp_decay         (paper t^(5c))
+#   transitivity_exp_decay_ordered (paper t^(6c))
+
+# Brute-force computation of paper t^(5c)/t^(6c) given a prior event log.
+# For each intermediary k, the chain s -> k -> r contributes a single
+# exp-decayed term centred on its formation time. The half_life T defines
+# the decay rate ln 2 / T. `ordered = TRUE` further requires s -> k to
+# fire strictly before k -> r.
+expected_decay <- function(prior, s, r, t_now, half_life, actors,
+                            ordered = FALSE) {
+  if (!nrow(prior)) return(0)
+  decay_rate <- log(2) / half_life
+  out <- 0
+  for (k in actors) {
+    if (k == s || k == r) next
+    leg1 <- prior$time[prior$sender == s & prior$receiver == k]
+    leg2 <- prior$time[prior$sender == k & prior$receiver == r]
+    if (!length(leg1) || !length(leg2)) next
+    if (ordered) {
+      # First k -> r event strictly after first s -> k event
+      valid_leg2 <- leg2[leg2 > min(leg1)]
+      if (!length(valid_leg2)) next
+      formation <- min(valid_leg2)
+    } else {
+      # Two-path formation = time the second leg first appears
+      formation <- max(min(leg1), min(leg2))
+    }
+    out <- out + exp(-(t_now - formation) * decay_rate)
+  }
+  out
+}
+
+test_that("transitivity_exp_decay matches brute force t^(5c) computation", {
+  set.seed(31)
+  hl <- 0.5
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "transitivity_exp_decay",
+    endogenous_effects = 0,
+    half_life = hl
+  )
+  actors <- LETTERS[1:5]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    exp_val <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], hl, actors, ordered = FALSE)
+    expect_equal(ev$transitivity_exp_decay[i], exp_val,
+                 tolerance = 1e-9, info = paste("row", i))
+  }
+})
+
+test_that("transitivity_exp_decay_ordered matches brute force t^(6c) computation", {
+  set.seed(32)
+  hl <- 0.8
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = "transitivity_exp_decay_ordered",
+    endogenous_effects = 0,
+    half_life = hl
+  )
+  actors <- LETTERS[1:5]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    exp_val <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], hl, actors, ordered = TRUE)
+    expect_equal(ev$transitivity_exp_decay_ordered[i], exp_val,
+                 tolerance = 1e-9, info = paste("row", i))
+  }
+})
+
+test_that("ordered exp_decay agrees with unordered when natural-order chains hold", {
+  # When every chain s -> k -> r is formed in chronological order
+  # (every k has min(s -> k) < min(k -> r)), the ordered and unordered
+  # exp_decay totals must coincide -- the formation time is identical
+  # for both definitions. Constructively schedule such a regime by
+  # using a moderate baseline rate and a one-mode universe, then check
+  # row-by-row that whenever the ordered total is positive it equals
+  # the unordered total for the chains that hold the natural order.
+  # (The general inequality `ordered <= unordered` does NOT hold: a
+  # later ordered-formation time yields LESS decay and hence a LARGER
+  # contribution per chain, even though the ordered set is a subset.)
+  set.seed(33)
+  hl <- 1
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_exp_decay",
+                         "transitivity_exp_decay_ordered"),
+    endogenous_effects = c(transitivity_exp_decay = 0,
+                            transitivity_exp_decay_ordered = 0),
+    half_life = hl
+  )
+  actors <- LETTERS[1:5]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    e_unord <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], hl, actors, ordered = FALSE)
+    e_ord   <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], hl, actors, ordered = TRUE)
+    expect_equal(ev$transitivity_exp_decay[i],         e_unord, tolerance = 1e-9)
+    expect_equal(ev$transitivity_exp_decay_ordered[i], e_ord,   tolerance = 1e-9)
+  }
+})
+
+test_that("exp_decay stats are 0 when transitivity_count is 0", {
+  set.seed(34)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_count", "transitivity_exp_decay"),
+    endogenous_effects = c(transitivity_count = 0, transitivity_exp_decay = 0),
+    half_life = 1
+  )
+  zero <- ev$transitivity_count == 0
+  expect_true(all(ev$transitivity_exp_decay[zero] == 0))
+})
+
+test_that("exp_decay stats decay over time with the configured half_life", {
+  # Schedule a deterministic sequence: an s-k-r chain forms at t = 0,
+  # then no further events for a long stretch.  The unordered exp_decay
+  # at the closing s -> r event should be exp(-(t_close - 0) * ln 2 / T).
+  set.seed(35)
+  T_half <- 2
+  # Use very low baseline_rate so the simulator produces sparse output,
+  # making the brute-force check tight.
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 0.3,
+    endogenous_stats = "transitivity_exp_decay",
+    endogenous_effects = 0,
+    half_life = T_half
+  )
+  actors <- LETTERS[1:5]
+  decay_rate <- log(2) / T_half
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    exp_val <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], T_half, actors, ordered = FALSE)
+    expect_equal(ev$transitivity_exp_decay[i], exp_val,
+                 tolerance = 1e-9, info = paste("row", i))
+  }
+})
+
+test_that("half_life is required when an exp-decay stat is requested", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      endogenous_stats = "transitivity_exp_decay",
+      endogenous_effects = 0
+    ),
+    "half_life"
+  )
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      endogenous_stats = "transitivity_exp_decay_ordered",
+      endogenous_effects = 0
+    ),
+    "half_life"
+  )
+})
+
+test_that("exp_decay stats run under tau-leap and stay non-negative", {
+  set.seed(36)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("transitivity_exp_decay",
+                         "transitivity_exp_decay_ordered"),
+    endogenous_effects = c(transitivity_exp_decay = 0,
+                            transitivity_exp_decay_ordered = 0),
+    half_life = 1,
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true(all(ev$transitivity_exp_decay >= 0))
+  expect_true(all(ev$transitivity_exp_decay_ordered >= 0))
+})
+
+test_that("exp_decay stats error on bipartite settings (one-mode required)", {
+  for (st in c("transitivity_exp_decay", "transitivity_exp_decay_ordered")) {
+    expect_error(
+      simulate_relational_events(
+        n_events = 5,
+        senders = c("a", "b"), receivers = c("x", "y", "z"),
+        endogenous_stats = st,
+        endogenous_effects = 0.5,
+        half_life = 1
+      ),
+      "one-mode",
+      info = st
+    )
+  }
+})
+
+test_that("a positive coefficient on transitivity_exp_decay is sign-recoverable", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+  set.seed(2026)
+  true_beta <- 0.4
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "transitivity_exp_decay",
+    endogenous_effects = true_beta,
+    half_life = 1
+  )
+  cases <- cc[cc$event == 1L, ]; cases <- cases[order(cases$stratum), ]
+  ctrls <- cc[cc$event == 0L, ]; ctrls <- ctrls[order(ctrls$stratum), ]
+  df <- data.frame(
+    one     = rep(1, nrow(cases)),
+    delta_d = cases$transitivity_exp_decay - ctrls$transitivity_exp_decay
+  )
+  fit <- gam(one ~ delta_d - 1, family = "binomial", data = df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.15 && est < 0.7,
+              info = sprintf("estimated exp_decay effect = %.3f", est))
+})
+
+test_that("reciprocity_exp_decay still works alongside the new exp_decay stats", {
+  # The has_exp_decay / apply_exp_decay refactor must not break the
+  # pre-existing reciprocity_exp_decay path.
+  set.seed(37)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_exp_decay", "transitivity_exp_decay"),
+    endogenous_effects = c(reciprocity_exp_decay = 0,
+                            transitivity_exp_decay = 0),
+    half_life = 0.5
+  )
+  expect_true(all(ev$reciprocity_exp_decay >= 0))
+  expect_true(all(ev$transitivity_exp_decay >= 0))
+})


### PR DESCRIPTION
## Summary

Wires the two exp-decay transitivity statistics into the generative simulator:

- \`transitivity_exp_decay\` — paper definition t^(5c). For each intermediary k, the two-path s → k → r contributes a single exp-decayed term centred on its formation time (= time the second of its two legs is first observed). The state aggregates these contributions.
- \`transitivity_exp_decay_ordered\` — paper definition t^(6c). Same, but the chain must be chronologically ordered (s → k strictly before k → r).

## Implementation highlights

- Generalised \`apply_exp_decay()\` from a single hard-coded \`reciprocity_exp_decay\` matrix to a loop over every active exp_decay state. All exp_decay stats share the same \`decay_rate = log 2 / half_life\`, matching the convention in Juozaitienė & Wit (2024).
- Unordered increment piggybacks on \`two_path_writes(\"transitivity\", …)\` and the existing first-fire gate.
- Ordered increment piggybacks on \`apply_ordered_update()\`'s \`ordered_validation_mask\` sweep — same path that already drives count/binary/time_* ordered stats.

## Test plan

- [x] \`tests/testthat/test-transitivity-exp-decay.R\` (10 blocks, 150 assertions): exact row-by-row equality vs. a brute-force enumerator of t^(5c) / t^(6c) on three regimes; \`exp_decay == 0\` iff \`transitivity_count == 0\`; missing \`half_life\` raises; tau-leap stays non-negative; bipartite raises; GAM sign-recovery; regression test that \`reciprocity_exp_decay\` still works alongside the new stats.
- [x] Full suite: 1588 PASS / 0 FAIL.
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (all pre-existing).