### PR TITLE
Post-hoc / simulator parity: formation-time fix + _time_first variants

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -251,8 +251,10 @@ attach_static_covariates <- function(
 #'   \describe{
 #'     \item{`cyclic_binary`}{1 if any cyclic two-path exists.}
 #'     \item{`cyclic_count`}{Number of cyclic intermediaries.}
-#'     \item{`cyclic_time_recent`}{Time since the most recent cyclic two-path;
-#'       `NA` if none.}
+#'     \item{`cyclic_time_recent`}{Time since the most recent cyclic two-path
+#'       formation; `NA` if none.}
+#'     \item{`cyclic_time_first`}{Time since the first cyclic two-path
+#'       formation; `NA` if none.}
 #'   }
 #'
 #'   **Sending balance** — shared target: both \eqn{s \to k} and \eqn{r \to k}
@@ -261,7 +263,9 @@ attach_static_covariates <- function(
 #'     \item{`sending_balance_binary`}{1 if any shared target exists.}
 #'     \item{`sending_balance_count`}{Number of shared targets.}
 #'     \item{`sending_balance_time_recent`}{Time since the most recent
-#'       shared-target two-path; `NA` if none.}
+#'       shared-target two-path formation; `NA` if none.}
+#'     \item{`sending_balance_time_first`}{Time since the first
+#'       shared-target two-path formation; `NA` if none.}
 #'   }
 #'
 #'   **Receiving balance** — shared source: both \eqn{k \to s} and
@@ -270,7 +274,9 @@ attach_static_covariates <- function(
 #'     \item{`receiving_balance_binary`}{1 if any shared source exists.}
 #'     \item{`receiving_balance_count`}{Number of shared sources.}
 #'     \item{`receiving_balance_time_recent`}{Time since the most recent
-#'       shared-source two-path; `NA` if none.}
+#'       shared-source two-path formation; `NA` if none.}
+#'     \item{`receiving_balance_time_first`}{Time since the first
+#'       shared-source two-path formation; `NA` if none.}
 #'   }
 #'
 #' @return The event log with added columns, one per requested statistic.
@@ -300,11 +306,11 @@ compute_endogenous_features <- function(
     "transitivity_exp_decay", "transitivity_exp_decay_ordered",
     "transitivity_time_recent", "transitivity_time_first",
     "transitivity_time_recent_ordered", "transitivity_time_first_ordered",
-    "cyclic_binary", "cyclic_count", "cyclic_time_recent",
+    "cyclic_binary", "cyclic_count", "cyclic_time_recent", "cyclic_time_first",
     "sending_balance_binary", "sending_balance_count",
-    "sending_balance_time_recent",
+    "sending_balance_time_recent", "sending_balance_time_first",
     "receiving_balance_binary", "receiving_balance_count",
-    "receiving_balance_time_recent"
+    "receiving_balance_time_recent", "receiving_balance_time_first"
   )
   bad <- setdiff(stats, allowed)
   if (length(bad)) {
@@ -341,11 +347,12 @@ compute_endogenous_features <- function(
                    "transitivity_time_recent", "transitivity_time_first",
                    "transitivity_time_recent_ordered",
                    "transitivity_time_first_ordered")
-  cyc_names   <- c("cyclic_binary", "cyclic_count", "cyclic_time_recent")
+  cyc_names   <- c("cyclic_binary", "cyclic_count",
+                   "cyclic_time_recent", "cyclic_time_first")
   sb_names    <- c("sending_balance_binary", "sending_balance_count",
-                   "sending_balance_time_recent")
+                   "sending_balance_time_recent", "sending_balance_time_first")
   rb_names    <- c("receiving_balance_binary", "receiving_balance_count",
-                   "receiving_balance_time_recent")
+                   "receiving_balance_time_recent", "receiving_balance_time_first")
   need_triadic <- any(c(trans_names, cyc_names, sb_names, rb_names) %in% stats)
 
   # --- Tracking data structures ---
@@ -432,30 +439,34 @@ compute_endogenous_features <- function(
       e1 <- get_e1_times(k)
       e2 <- get_e2_times(k)
 
-      last_e1  <- max(e1)
-      last_e2  <- max(e2)
-      completion <- max(last_e1, last_e2)
+      # Per-k formation time = the time the two-path s -> k -> r first
+      # exists, i.e., the time the second of its two legs is first
+      # observed (paper t^(7) family; matches the simulator's
+      # apply_time_writes contract). Re-firings of either leg do not
+      # change the formation time.
+      formation <- max(min(e1), min(e2))
 
       if (need_time) {
-        if (completion > form_recent) form_recent <- completion
-        first_completion <- max(min(e1), min(e2))
-        if (first_completion < form_first) form_first <- first_completion
+        if (formation > form_recent) form_recent <- formation
+        if (formation < form_first)  form_first  <- formation
       }
       if (need_exp && !is.null(half_life)) {
         exp_sum <- exp_sum +
-          exp(-(t_now - completion) * log(2) / half_life)
+          exp(-(t_now - formation) * log(2) / half_life)
       }
       if (need_ord) {
+        # First leg-2 event strictly after the first leg-1 event is the
+        # ordered chain's formation time. Across k, take max for
+        # form_ord_recent and min for form_ord_first.
         valid_e2 <- e2[e2 > min(e1)]
         if (length(valid_e2)) {
           n_ordered <- n_ordered + 1L
-          latest_v   <- max(valid_e2)
-          earliest_v <- min(valid_e2)
-          if (latest_v > form_ord_recent) form_ord_recent <- latest_v
-          if (earliest_v < form_ord_first) form_ord_first <- earliest_v
+          formation_ord <- min(valid_e2)
+          if (formation_ord > form_ord_recent) form_ord_recent <- formation_ord
+          if (formation_ord < form_ord_first)  form_ord_first  <- formation_ord
           if (need_exp && !is.null(half_life)) {
             exp_ord_sum <- exp_ord_sum +
-              exp(-(t_now - latest_v) * log(2) / half_life)
+              exp(-(t_now - formation_ord) * log(2) / half_life)
           }
         }
       }

--- a/man/compute_endogenous_features.Rd
+++ b/man/compute_endogenous_features.Rd
@@ -89,8 +89,10 @@ two-path; \code{NA} if none.}
 \describe{
 \item{\code{cyclic_binary}}{1 if any cyclic two-path exists.}
 \item{\code{cyclic_count}}{Number of cyclic intermediaries.}
-\item{\code{cyclic_time_recent}}{Time since the most recent cyclic two-path;
-\code{NA} if none.}
+\item{\code{cyclic_time_recent}}{Time since the most recent cyclic two-path
+formation; \code{NA} if none.}
+\item{\code{cyclic_time_first}}{Time since the first cyclic two-path
+formation; \code{NA} if none.}
 }
 
 \strong{Sending balance} — shared target: both \eqn{s \to k} and \eqn{r \to k}
@@ -99,7 +101,9 @@ exist:
 \item{\code{sending_balance_binary}}{1 if any shared target exists.}
 \item{\code{sending_balance_count}}{Number of shared targets.}
 \item{\code{sending_balance_time_recent}}{Time since the most recent
-shared-target two-path; \code{NA} if none.}
+shared-target two-path formation; \code{NA} if none.}
+\item{\code{sending_balance_time_first}}{Time since the first
+shared-target two-path formation; \code{NA} if none.}
 }
 
 \strong{Receiving balance} — shared source: both \eqn{k \to s} and
@@ -108,6 +112,8 @@ shared-target two-path; \code{NA} if none.}
 \item{\code{receiving_balance_binary}}{1 if any shared source exists.}
 \item{\code{receiving_balance_count}}{Number of shared sources.}
 \item{\code{receiving_balance_time_recent}}{Time since the most recent
-shared-source two-path; \code{NA} if none.}
+shared-source two-path formation; \code{NA} if none.}
+\item{\code{receiving_balance_time_first}}{Time since the first
+shared-source two-path formation; \code{NA} if none.}
 }
 }

--- a/tests/testthat/test-sim-vs-posthoc-parity.R
+++ b/tests/testthat/test-sim-vs-posthoc-parity.R
@@ -1,0 +1,125 @@
+# test-sim-vs-posthoc-parity.R
+# Cross-validation: for every endogenous statistic that both the
+# simulator and compute_endogenous_features() support, the two paths
+# must agree row-by-row on the same event log.
+#
+# The simulator computes each stat at the time the event fires
+# (immediately before it fires). compute_endogenous_features() does
+# the same when applied to the resulting event table. If both
+# implementations follow paper semantics they must produce identical
+# columns.
+
+# Helper: run the simulator with the given stats list, then strip the
+# endogenous columns and re-compute them post-hoc. Returns a list with
+# the two data frames keyed by stat name.
+sim_vs_posthoc <- function(stats, seed = 11, n_events = 25,
+                            n_actors = 5, half_life = NULL,
+                            baseline_rate = 3) {
+  set.seed(seed)
+  effs <- setNames(rep(0, length(stats)), stats)
+  args <- list(
+    n_events = n_events,
+    senders = LETTERS[1:n_actors],
+    receivers = LETTERS[1:n_actors],
+    baseline_rate = baseline_rate,
+    endogenous_stats = stats,
+    endogenous_effects = effs
+  )
+  if (!is.null(half_life)) args$half_life <- half_life
+  ev <- do.call(simulate_relational_events, args)
+  base <- ev[, c("sender", "receiver", "time")]
+  feats <- compute_endogenous_features(base, stats = stats,
+                                        half_life = half_life)
+  list(sim = ev, posthoc = feats)
+}
+
+# Per-stat equality with a small tolerance. compute_endogenous_features()
+# returns NA for never-observed timing slots; the simulator returns 0.
+# Treat the two as equivalent (the simulator's 0 means "no such
+# two-path yet", same condition that triggers NA post-hoc).
+expect_columns_match <- function(sim, ph, stat) {
+  v_sim <- sim[[stat]]
+  v_ph  <- ph[[stat]]
+  expect_false(is.null(v_sim), info = paste("simulator missing", stat))
+  expect_false(is.null(v_ph),  info = paste("post-hoc missing",  stat))
+  v_ph[is.na(v_ph)] <- 0
+  expect_equal(v_sim, v_ph, tolerance = 1e-9, info = stat)
+}
+
+test_that("simulator and post-hoc agree on reciprocity-family stats", {
+  stats <- c("reciprocity_binary", "reciprocity_count",
+             "reciprocity_exp_decay",
+             "reciprocity_time_recent", "reciprocity_time_first")
+  out <- sim_vs_posthoc(stats, seed = 101, half_life = 1)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on transitivity unordered stats", {
+  stats <- c("transitivity_binary", "transitivity_count",
+             "transitivity_time_recent", "transitivity_time_first",
+             "transitivity_exp_decay")
+  out <- sim_vs_posthoc(stats, seed = 102, half_life = 1)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on transitivity ordered stats", {
+  stats <- c("transitivity_binary_ordered", "transitivity_count_ordered",
+             "transitivity_time_recent_ordered",
+             "transitivity_time_first_ordered",
+             "transitivity_exp_decay_ordered")
+  out <- sim_vs_posthoc(stats, seed = 103, half_life = 1)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on cyclic stats", {
+  stats <- c("cyclic_binary", "cyclic_count",
+             "cyclic_time_recent", "cyclic_time_first")
+  out <- sim_vs_posthoc(stats, seed = 104)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on sending_balance stats", {
+  stats <- c("sending_balance_binary", "sending_balance_count",
+             "sending_balance_time_recent", "sending_balance_time_first")
+  out <- sim_vs_posthoc(stats, seed = 105)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on receiving_balance stats", {
+  stats <- c("receiving_balance_binary", "receiving_balance_count",
+             "receiving_balance_time_recent", "receiving_balance_time_first")
+  out <- sim_vs_posthoc(stats, seed = 106)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
+test_that("simulator and post-hoc agree on per-actor / single-direction stats", {
+  stats <- c("sender_outdegree", "receiver_indegree", "recency")
+  set.seed(107)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = stats,
+    endogenous_effects = setNames(rep(0, length(stats)), stats)
+  )
+  base <- ev[, c("sender", "receiver", "time")]
+  feats <- compute_endogenous_features(base, stats = stats)
+  # `recency`: simulator initialises to `start_time` so the elapsed
+  # time at row 1 is the event time - start_time = the event time
+  # (start_time defaults to 0). Post-hoc returns NA for never-seen
+  # dyads; coerce NA -> sim value (= the event time on the first
+  # firing of each dyad) only on the first occurrence of each dyad.
+  feats$recency[is.na(feats$recency)] <- ev$recency[is.na(feats$recency)]
+  for (st in stats) expect_equal(ev[[st]], feats[[st]], tolerance = 1e-9,
+                                  info = st)
+})
+
+test_that("simulator and post-hoc agree on a mixed cross-family stat bundle", {
+  stats <- c("reciprocity_count", "reciprocity_time_recent",
+             "transitivity_count", "transitivity_time_recent",
+             "cyclic_count", "cyclic_time_recent",
+             "sending_balance_count", "sending_balance_time_recent",
+             "sender_outdegree", "receiver_indegree")
+  out <- sim_vs_posthoc(stats, seed = 108)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})


### PR DESCRIPTION
## Summary

Two related fixes to \`compute_endogenous_features()\`:

1. **Formation-time bug in \`compute_triadic\`.** The per-k completion variable was \`max(max(e1), max(e2))\` (max over all firings of either leg). The paper and simulator use the *formation* time = \`max(min(e1), min(e2))\` (time the second of the two legs is first observed). The bug was invisible in the existing test suite because every test case used single-firing-per-leg sequences, where the two formulas coincide.

2. **Three missing \`_time_first\` variants.** Added \`cyclic_time_first\`, \`sending_balance_time_first\`, \`receiving_balance_time_first\` to the allowed list, the per-family name groupings, and the doc. \`compute_triadic\` already supported them via its generic \`_time_first\` branch — only the caller-side wiring was missing.

3. **Cross-validation suite.** \`test-sim-vs-posthoc-parity.R\` (114 assertions): for every stat both paths support, simulate a small REM and verify \`compute_endogenous_features\` reproduces the simulator's columns row-for-row. Covers all 23 shared stats.

## Test plan

- [x] Targeted: \`test-sim-vs-posthoc-parity.R\` 114 PASS / 0 FAIL.
- [x] Full suite: 1702 PASS / 0 FAIL (was 1588; +114 parity assertions).
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (pre-existing).