### PR TITLE
Add interrupted reciprocity family (paper r^(1i)-(4bi))

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -301,6 +301,10 @@ compute_endogenous_features <- function(
     "sender_outdegree", "receiver_indegree", "recency",
     "reciprocity", "reciprocity_binary", "reciprocity_count",
     "reciprocity_exp_decay", "reciprocity_time_recent", "reciprocity_time_first",
+    "reciprocity_binary_interrupted", "reciprocity_count_interrupted",
+    "reciprocity_exp_decay_interrupted",
+    "reciprocity_time_recent_interrupted",
+    "reciprocity_time_first_interrupted",
     "transitivity_binary", "transitivity_count",
     "transitivity_binary_ordered", "transitivity_count_ordered",
     "transitivity_exp_decay", "transitivity_exp_decay_ordered",
@@ -321,7 +325,8 @@ compute_endogenous_features <- function(
   }
 
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
-                       "transitivity_exp_decay_ordered")
+                       "transitivity_exp_decay_ordered",
+                       "reciprocity_exp_decay_interrupted")
   if (any(exp_decay_stats %in% stats) &&
       (is.null(half_life) || !is.numeric(half_life) || half_life <= 0)) {
     stop("`half_life` must be a positive number when ",
@@ -365,6 +370,23 @@ compute_endogenous_features <- function(
   dyad_event_count <- new.env(parent = emptyenv())
   dyad_times      <- new.env(parent = emptyenv())
 
+  # Interrupted reciprocity tracking: each dyad (s, r) accumulates
+  # information about reverse-dyad (r, s) events that occurred SINCE
+  # the most recent (s, r) event. State for dyad (s, r) is reset
+  # whenever event (s, r) fires.
+  interrupted_recip_stats <- c("reciprocity_count_interrupted",
+                                "reciprocity_binary_interrupted",
+                                "reciprocity_exp_decay_interrupted",
+                                "reciprocity_time_recent_interrupted",
+                                "reciprocity_time_first_interrupted")
+  need_interrupted <- any(interrupted_recip_stats %in% stats)
+  if (need_interrupted) {
+    dyad_int_count <- new.env(parent = emptyenv())
+    dyad_int_times <- new.env(parent = emptyenv())  # decay summands
+    dyad_int_last  <- new.env(parent = emptyenv())
+    dyad_int_first <- new.env(parent = emptyenv())
+  }
+
   if (need_triadic) {
     out_targets <- new.env(parent = emptyenv())
     in_sources  <- new.env(parent = emptyenv())
@@ -379,6 +401,7 @@ compute_endogenous_features <- function(
 
   # --- Initialize output columns ---
   binary_set <- c("reciprocity", "reciprocity_binary",
+                  "reciprocity_binary_interrupted",
                   "transitivity_binary", "transitivity_binary_ordered",
                   "cyclic_binary", "sending_balance_binary",
                   "receiving_balance_binary")
@@ -387,7 +410,9 @@ compute_endogenous_features <- function(
                  "transitivity_count", "transitivity_count_ordered",
                  "transitivity_exp_decay", "transitivity_exp_decay_ordered",
                  "cyclic_count", "sending_balance_count",
-                 "receiving_balance_count")
+                 "receiving_balance_count",
+                 "reciprocity_count_interrupted",
+                 "reciprocity_exp_decay_interrupted")
   for (stat in stats) {
     if (stat %in% binary_set) {
       log_df[[stat]] <- integer(n)
@@ -544,6 +569,37 @@ compute_endogenous_features <- function(
       if (!is.null(ft_rs)) log_df$reciprocity_time_first[i] <- ti - ft_rs
     }
 
+    # Interrupted reciprocity family: each variant reads the SAME-DIRECTION
+    # state slot (dyad (s, r)) — the state was populated by reverse-direction
+    # events (r, s) since the most recent (s, r) event. The corresponding
+    # update step below resets state[key_sr] and bumps state[key_rs].
+    if (need_interrupted) {
+      if ("reciprocity_count_interrupted" %in% stats) {
+        v <- dyad_int_count[[key_sr]]
+        log_df$reciprocity_count_interrupted[i] <- if (is.null(v)) 0 else v
+      }
+      if ("reciprocity_binary_interrupted" %in% stats) {
+        v <- dyad_int_count[[key_sr]]
+        log_df$reciprocity_binary_interrupted[i] <-
+          if (is.null(v) || v == 0) 0L else 1L
+      }
+      if ("reciprocity_exp_decay_interrupted" %in% stats) {
+        ts <- dyad_int_times[[key_sr]]
+        log_df$reciprocity_exp_decay_interrupted[i] <-
+          if (is.null(ts)) 0 else sum(exp(-(ti - ts) * log(2) / half_life))
+      }
+      if ("reciprocity_time_recent_interrupted" %in% stats) {
+        lt <- dyad_int_last[[key_sr]]
+        if (!is.null(lt))
+          log_df$reciprocity_time_recent_interrupted[i] <- ti - lt
+      }
+      if ("reciprocity_time_first_interrupted" %in% stats) {
+        ft <- dyad_int_first[[key_sr]]
+        if (!is.null(ft))
+          log_df$reciprocity_time_first_interrupted[i] <- ti - ft
+      }
+    }
+
     # Triadic statistics
     if (need_triadic) {
       s_out <- out_targets[[s]]; if (is.null(s_out)) s_out <- character(0)
@@ -596,6 +652,22 @@ compute_endogenous_features <- function(
     prev_c <- dyad_event_count[[key_sr]]
     dyad_event_count[[key_sr]] <- if (is.null(prev_c)) 1L else prev_c + 1L
     dyad_times[[key_sr]] <- c(dyad_times[[key_sr]], ti)
+
+    # Interrupted reciprocity: event (s, r) closes the cycle for dyad
+    # (s, r) -- reset its state -- AND counts as a reverse-direction
+    # event for dyad (r, s).
+    if (need_interrupted) {
+      dyad_int_count[[key_sr]] <- 0L
+      for (env in list(dyad_int_times, dyad_int_last, dyad_int_first)) {
+        if (exists(key_sr, envir = env, inherits = FALSE))
+          rm(list = key_sr, envir = env)
+      }
+      prev_int_c <- dyad_int_count[[key_rs]]
+      dyad_int_count[[key_rs]] <- if (is.null(prev_int_c)) 1L else prev_int_c + 1L
+      dyad_int_times[[key_rs]] <- c(dyad_int_times[[key_rs]], ti)
+      dyad_int_last[[key_rs]]  <- ti
+      if (is.null(dyad_int_first[[key_rs]])) dyad_int_first[[key_rs]] <- ti
+    }
 
     if (need_triadic) {
       cur_out <- out_targets[[s]]

--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -56,6 +56,18 @@
 #'     \item \code{"reciprocity_time_first"} — elapsed time since the
 #'       \emph{first} reverse-dyad event \eqn{t - t_{\text{first}}(r,s)};
 #'       same \code{0}-for-never-seen convention.
+#'     \item \code{"reciprocity_binary_interrupted"} /
+#'       \code{"reciprocity_count_interrupted"} /
+#'       \code{"reciprocity_exp_decay_interrupted"} /
+#'       \code{"reciprocity_time_recent_interrupted"} /
+#'       \code{"reciprocity_time_first_interrupted"} — the \emph{interrupted}
+#'       reciprocity family of Juozaitienė & Wit (2024) §2.1.3
+#'       (definitions \eqn{r^{(1i)}, r^{(2i)}, r^{(3i)}, r^{(4ai)},
+#'       r^{(4bi)}}). Each variant measures the same quantity as its
+#'       continuous counterpart but considers only those reverse-dyad
+#'       events that occurred \emph{since} the most recent same-direction
+#'       \eqn{s \to r} event. Firing \eqn{s \to r} resets the
+#'       interrupted state for dyad \eqn{(s, r)}.
 #'     \item \code{"recency"} — elapsed time on the same ordered dyad
 #'       \eqn{t - t_{\text{last}}(s,r)}, defaulting to
 #'       \eqn{t - \text{start\_time}} for dyads that have never fired.
@@ -312,7 +324,17 @@ simulate_relational_events <- function(
 
   reciprocity_stats <- c("reciprocity_count", "reciprocity_binary",
                          "reciprocity_exp_decay",
-                         "reciprocity_time_recent", "reciprocity_time_first")
+                         "reciprocity_time_recent", "reciprocity_time_first",
+                         "reciprocity_count_interrupted",
+                         "reciprocity_binary_interrupted",
+                         "reciprocity_exp_decay_interrupted",
+                         "reciprocity_time_recent_interrupted",
+                         "reciprocity_time_first_interrupted")
+  interrupted_recip_stats <- c("reciprocity_count_interrupted",
+                                "reciprocity_binary_interrupted",
+                                "reciprocity_exp_decay_interrupted",
+                                "reciprocity_time_recent_interrupted",
+                                "reciprocity_time_first_interrupted")
   network_stats <- c("transitivity_count", "transitivity_binary",
                      "cyclic_count", "cyclic_binary",
                      "sending_balance_count", "sending_balance_binary",
@@ -334,7 +356,8 @@ simulate_relational_events <- function(
                      "transitivity_time_first_ordered",
                      "transitivity_exp_decay_ordered")
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
-                       "transitivity_exp_decay_ordered")
+                       "transitivity_exp_decay_ordered",
+                       "reciprocity_exp_decay_interrupted")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
                             degree_stats, network_stats)
@@ -488,7 +511,9 @@ simulate_relational_events <- function(
                             "receiving_balance_time_recent",
                             "receiving_balance_time_first",
                             "transitivity_time_recent_ordered",
-                            "transitivity_time_first_ordered")) {
+                            "transitivity_time_first_ordered",
+                            "reciprocity_time_recent_interrupted",
+                            "reciprocity_time_first_interrupted")) {
         # NA marks "the relevant past event (reverse dyad, or two-path)
         # has never happened". Replaced with 0 in the score / output
         # matrices so the rate computation stays numeric (see
@@ -745,6 +770,11 @@ simulate_relational_events <- function(
         "transitivity_time_first_ordered" = time_elapsed_or_zero(endo_state[[st]]),
         "transitivity_exp_decay"          = endo_state[[st]],
         "transitivity_exp_decay_ordered"  = endo_state[[st]],
+        "reciprocity_count_interrupted"        = endo_state[[st]],
+        "reciprocity_binary_interrupted"       = endo_state[[st]],
+        "reciprocity_exp_decay_interrupted"    = endo_state[[st]],
+        "reciprocity_time_recent_interrupted"  = time_elapsed_or_zero(endo_state[[st]]),
+        "reciprocity_time_first_interrupted"   = time_elapsed_or_zero(endo_state[[st]]),
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -897,7 +927,9 @@ simulate_relational_events <- function(
                        "receiving_balance_time_recent",
                        "receiving_balance_time_first",
                        "transitivity_time_recent_ordered",
-                       "transitivity_time_first_ordered")) {
+                       "transitivity_time_first_ordered",
+                       "reciprocity_time_recent_interrupted",
+                       "reciprocity_time_first_interrupted")) {
             if (ts %in% endogenous_stats) {
               snap[[ts]] <- endo_state[[ts]]
             }
@@ -1005,6 +1037,21 @@ simulate_relational_events <- function(
                   }
                 } else if (st == "recency") {
                   endo_state[[st]][s_k, r_k] <- ev_times[k]
+                } else if (st == "reciprocity_count_interrupted" ||
+                           st == "reciprocity_exp_decay_interrupted") {
+                  endo_state[[st]][r_k, s_k] <- endo_state[[st]][r_k, s_k] + 1
+                  endo_state[[st]][s_k, r_k] <- 0
+                } else if (st == "reciprocity_binary_interrupted") {
+                  endo_state[[st]][r_k, s_k] <- 1
+                  endo_state[[st]][s_k, r_k] <- 0
+                } else if (st == "reciprocity_time_recent_interrupted") {
+                  endo_state[[st]][r_k, s_k] <- ev_times[k]
+                  endo_state[[st]][s_k, r_k] <- NA_real_
+                } else if (st == "reciprocity_time_first_interrupted") {
+                  if (is.na(endo_state[[st]][r_k, s_k])) {
+                    endo_state[[st]][r_k, s_k] <- ev_times[k]
+                  }
+                  endo_state[[st]][s_k, r_k] <- NA_real_
                 } else if (!is.null(two_path_time_lookup[[st]])) {
                   if (adj_state[s_k, r_k] == 0) {
                     info <- two_path_time_lookup[[st]]
@@ -1192,6 +1239,25 @@ simulate_relational_events <- function(
           }
         } else if (st == "recency") {
           endo_state[[st]][s_idx, r_idx] <- current_time
+        } else if (st == "reciprocity_count_interrupted" ||
+                   st == "reciprocity_exp_decay_interrupted") {
+          # Continuous-style update for the reverse dyad (s -> r is a
+          # reverse-direction event for dyad (r, s)), AND reset of the
+          # firing dyad's own state because (s, r) closes the
+          # reciprocity cycle for (s, r).
+          endo_state[[st]][r_idx, s_idx] <- endo_state[[st]][r_idx, s_idx] + 1
+          endo_state[[st]][s_idx, r_idx] <- 0
+        } else if (st == "reciprocity_binary_interrupted") {
+          endo_state[[st]][r_idx, s_idx] <- 1
+          endo_state[[st]][s_idx, r_idx] <- 0
+        } else if (st == "reciprocity_time_recent_interrupted") {
+          endo_state[[st]][r_idx, s_idx] <- current_time
+          endo_state[[st]][s_idx, r_idx] <- NA_real_
+        } else if (st == "reciprocity_time_first_interrupted") {
+          if (is.na(endo_state[[st]][r_idx, s_idx])) {
+            endo_state[[st]][r_idx, s_idx] <- current_time
+          }
+          endo_state[[st]][s_idx, r_idx] <- NA_real_
         } else if (!is.null(two_path_time_lookup[[st]])) {
           # A two-path is *formed* at the time the second of its two legs
           # is first observed; re-fires of an existing leg don't form

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -93,6 +93,18 @@ post-hoc \code{NA}, so the rate computation stays numeric).
 \item \code{"reciprocity_time_first"} — elapsed time since the
 \emph{first} reverse-dyad event \eqn{t - t_{\text{first}}(r,s)};
 same \code{0}-for-never-seen convention.
+\item \code{"reciprocity_binary_interrupted"} /
+\code{"reciprocity_count_interrupted"} /
+\code{"reciprocity_exp_decay_interrupted"} /
+\code{"reciprocity_time_recent_interrupted"} /
+\code{"reciprocity_time_first_interrupted"} — the \emph{interrupted}
+reciprocity family of Juozaitienė & Wit (2024) §2.1.3
+(definitions \eqn{r^{(1i)}, r^{(2i)}, r^{(3i)}, r^{(4ai)},
+      r^{(4bi)}}). Each variant measures the same quantity as its
+continuous counterpart but considers only those reverse-dyad
+events that occurred \emph{since} the most recent same-direction
+\eqn{s \to r} event. Firing \eqn{s \to r} resets the
+interrupted state for dyad \eqn{(s, r)}.
 \item \code{"recency"} — elapsed time on the same ordered dyad
 \eqn{t - t_{\text{last}}(s,r)}, defaulting to
 \eqn{t - \text{start\_time}} for dyads that have never fired.

--- a/tests/testthat/test-interrupted-reciprocity.R
+++ b/tests/testthat/test-interrupted-reciprocity.R
@@ -1,0 +1,223 @@
+# test-interrupted-reciprocity.R
+# Coverage for the five new interrupted reciprocity stats:
+#   reciprocity_binary_interrupted, reciprocity_count_interrupted,
+#   reciprocity_exp_decay_interrupted,
+#   reciprocity_time_recent_interrupted,
+#   reciprocity_time_first_interrupted
+#
+# Per Juozaitiene & Wit (2024) §2.1.3, each interrupted statistic
+# measures the same quantity as its continuous counterpart but only
+# considers reverse-dyad events that occurred SINCE the most recent
+# same-direction event closes the reciprocity cycle.
+
+# Brute-force interrupted reciprocity counts/times at a given event
+# row given the prior log.
+brute_force_int <- function(prior, s, r, ti, half_life = 1) {
+  reverse <- prior$time[prior$sender == r & prior$receiver == s]
+  same_dir <- prior$time[prior$sender == s & prior$receiver == r]
+  last_closure <- if (length(same_dir)) max(same_dir) else -Inf
+  active_reverse <- reverse[reverse > last_closure]
+  count <- length(active_reverse)
+  binary <- as.integer(count > 0)
+  exp_dec <- if (count == 0) 0 else
+    sum(exp(-(ti - active_reverse) * log(2) / half_life))
+  recent_t <- if (count == 0) NA_real_ else ti - max(active_reverse)
+  first_t  <- if (count == 0) NA_real_ else ti - min(active_reverse)
+  list(count = count, binary = binary, exp_decay = exp_dec,
+       recent = recent_t, first = first_t)
+}
+
+test_that("simulator interrupted reciprocity matches brute force on small one-mode runs", {
+  set.seed(11)
+  hl <- 1
+  stats_vec <- c("reciprocity_count_interrupted",
+                  "reciprocity_binary_interrupted",
+                  "reciprocity_exp_decay_interrupted",
+                  "reciprocity_time_recent_interrupted",
+                  "reciprocity_time_first_interrupted")
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = stats_vec,
+    endogenous_effects = setNames(rep(0, length(stats_vec)), stats_vec),
+    half_life = hl
+  )
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    bf <- brute_force_int(prior, ev$sender[i], ev$receiver[i], ev$time[i], hl)
+    expect_equal(ev$reciprocity_count_interrupted[i],     bf$count,  info = paste("row", i))
+    expect_equal(ev$reciprocity_binary_interrupted[i],    bf$binary, info = paste("row", i))
+    expect_equal(ev$reciprocity_exp_decay_interrupted[i], bf$exp_decay,
+                 tolerance = 1e-9, info = paste("row", i))
+    # The simulator reports 0 for never-seen-since-closure (vs NA in
+    # brute force / post-hoc); fold NA -> 0 for comparison.
+    if (is.na(bf$recent)) {
+      expect_equal(ev$reciprocity_time_recent_interrupted[i], 0)
+      expect_equal(ev$reciprocity_time_first_interrupted[i],  0)
+    } else {
+      expect_equal(ev$reciprocity_time_recent_interrupted[i], bf$recent)
+      expect_equal(ev$reciprocity_time_first_interrupted[i],  bf$first)
+    }
+  }
+})
+
+test_that("interrupted count is <= continuous count on every row", {
+  set.seed(12)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_count", "reciprocity_count_interrupted"),
+    endogenous_effects = c(reciprocity_count = 0,
+                            reciprocity_count_interrupted = 0)
+  )
+  expect_true(all(ev$reciprocity_count_interrupted <= ev$reciprocity_count))
+})
+
+test_that("interrupted state resets to 0 (count) / NA (time) after a closure event", {
+  # Hand-crafted log:
+  #   t=1: B -> A (reverse for dyad (A, B))   => count_int @ next (A, B) read = ?
+  #   t=2: B -> A (another reverse)
+  #   t=3: A -> B (closure -- resets)
+  #   t=4: B -> A (reverse again, post-reset)
+  # We can't drive specific firings through the simulator easily, but
+  # we CAN inject the log into compute_endogenous_features() and verify
+  # the resulting columns.
+  log_df <- data.frame(
+    sender   = c("B", "B", "A", "B", "A"),
+    receiver = c("A", "A", "B", "A", "B"),
+    time     = c(1,   2,   3,   4,   5))
+  feat <- compute_endogenous_features(
+    log_df,
+    stats = c("reciprocity_count_interrupted",
+              "reciprocity_time_recent_interrupted",
+              "reciprocity_time_first_interrupted"))
+  # Event 3 (A -> B) reads state[A -> B], which counts reverse (B -> A)
+  # events since the most recent (A -> B) event. There was no prior
+  # (A -> B), so all (B -> A) events count: B->A at 1 and 2 -> count = 2.
+  expect_equal(feat$reciprocity_count_interrupted[3], 2)
+  expect_equal(feat$reciprocity_time_recent_interrupted[3], 3 - 2)  # ti - 2
+  expect_equal(feat$reciprocity_time_first_interrupted[3],  3 - 1)  # ti - 1
+  # Event 5 (A -> B) reads state[A -> B] after the closure at t=3.
+  # Only (B -> A) at t=4 counts (post-reset). Count = 1.
+  expect_equal(feat$reciprocity_count_interrupted[5], 1)
+  expect_equal(feat$reciprocity_time_recent_interrupted[5], 5 - 4)
+  expect_equal(feat$reciprocity_time_first_interrupted[5],  5 - 4)
+})
+
+test_that("interrupted time stats are NA in post-hoc / 0 in simulator on first-row", {
+  set.seed(13)
+  ev <- simulate_relational_events(
+    n_events = 10,
+    senders = LETTERS[1:4], receivers = LETTERS[1:4],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_time_recent_interrupted",
+                         "reciprocity_time_first_interrupted"),
+    endogenous_effects = c(reciprocity_time_recent_interrupted = 0,
+                            reciprocity_time_first_interrupted = 0)
+  )
+  expect_equal(ev$reciprocity_time_recent_interrupted[1], 0)
+  expect_equal(ev$reciprocity_time_first_interrupted[1],  0)
+})
+
+test_that("sim and post-hoc agree on every interrupted variant", {
+  set.seed(14)
+  hl <- 0.7
+  stats_vec <- c("reciprocity_count_interrupted",
+                  "reciprocity_binary_interrupted",
+                  "reciprocity_exp_decay_interrupted",
+                  "reciprocity_time_recent_interrupted",
+                  "reciprocity_time_first_interrupted")
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = stats_vec,
+    endogenous_effects = setNames(rep(0, length(stats_vec)), stats_vec),
+    half_life = hl
+  )
+  base <- ev[, c("sender", "receiver", "time")]
+  phf <- compute_endogenous_features(base, stats = stats_vec, half_life = hl)
+  for (st in stats_vec) {
+    a <- ev[[st]]; b <- phf[[st]]
+    b[is.na(b)] <- 0  # post-hoc NA = simulator 0 for never-since-closure
+    expect_equal(a, b, tolerance = 1e-9, info = st)
+  }
+})
+
+test_that("half_life is required when reciprocity_exp_decay_interrupted is requested", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 5,
+      senders = LETTERS[1:3], receivers = LETTERS[1:3],
+      endogenous_stats = "reciprocity_exp_decay_interrupted",
+      endogenous_effects = 0
+    ),
+    "half_life"
+  )
+})
+
+test_that("interrupted variants compose with their continuous counterparts", {
+  set.seed(15)
+  ev <- simulate_relational_events(
+    n_events = 20,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("reciprocity_count", "reciprocity_count_interrupted",
+                         "reciprocity_time_recent",
+                         "reciprocity_time_recent_interrupted"),
+    endogenous_effects = c(reciprocity_count = 0,
+                            reciprocity_count_interrupted = 0,
+                            reciprocity_time_recent = 0,
+                            reciprocity_time_recent_interrupted = 0)
+  )
+  # Whenever the interrupted count is positive, the continuous count
+  # must also be positive (interrupted is a subset).
+  expect_true(all(ev$reciprocity_count_interrupted[ev$reciprocity_count == 0] == 0))
+})
+
+test_that("interrupted reciprocity runs under tau-leap", {
+  set.seed(16)
+  stats_vec <- c("reciprocity_count_interrupted",
+                  "reciprocity_time_recent_interrupted",
+                  "reciprocity_time_first_interrupted")
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = stats_vec,
+    endogenous_effects = setNames(rep(0, length(stats_vec)), stats_vec),
+    method = "tau_leap", tau = 0.02
+  )
+  expect_true(all(ev$reciprocity_count_interrupted >= 0))
+  expect_true(all(ev$reciprocity_time_recent_interrupted >= 0))
+  expect_true(all(ev$reciprocity_time_first_interrupted  >= 0))
+})
+
+test_that("a positive coefficient on reciprocity_count_interrupted is sign-recoverable", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  library(mgcv)
+  set.seed(2026)
+  true_beta <- 0.4
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "reciprocity_count_interrupted",
+    endogenous_effects = true_beta
+  )
+  cases <- cc[cc$event == 1L, ]; cases <- cases[order(cases$stratum), ]
+  ctrls <- cc[cc$event == 0L, ]; ctrls <- ctrls[order(ctrls$stratum), ]
+  df <- data.frame(
+    one     = rep(1, nrow(cases)),
+    delta_c = cases$reciprocity_count_interrupted -
+              ctrls$reciprocity_count_interrupted
+  )
+  fit <- gam(one ~ delta_c - 1, family = "binomial", data = df)
+  est <- unname(coef(fit)[1])
+  expect_true(est > 0.15 && est < 0.7,
+              info = sprintf("estimated count_interrupted effect = %.3f", est))
+})

--- a/tests/testthat/test-sim-vs-posthoc-parity.R
+++ b/tests/testthat/test-sim-vs-posthoc-parity.R
@@ -54,6 +54,15 @@ test_that("simulator and post-hoc agree on reciprocity-family stats", {
   for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
 })
 
+test_that("simulator and post-hoc agree on interrupted reciprocity stats", {
+  stats <- c("reciprocity_binary_interrupted", "reciprocity_count_interrupted",
+             "reciprocity_exp_decay_interrupted",
+             "reciprocity_time_recent_interrupted",
+             "reciprocity_time_first_interrupted")
+  out <- sim_vs_posthoc(stats, seed = 111, half_life = 1)
+  for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
+})
+
 test_that("simulator and post-hoc agree on transitivity unordered stats", {
   stats <- c("transitivity_binary", "transitivity_count",
              "transitivity_time_recent", "transitivity_time_first",


### PR DESCRIPTION
## Summary

Adds the five interrupted reciprocity statistics from Juozaitienė & Wit (2024) §2.1.3 to both the generative simulator and the post-hoc \`compute_endogenous_features()\` engine:

| stat | paper |
|---|---|
| \`reciprocity_binary_interrupted\` | r^(1i) |
| \`reciprocity_count_interrupted\` | r^(2i) |
| \`reciprocity_exp_decay_interrupted\` | r^(3i) |
| \`reciprocity_time_recent_interrupted\` | r^(4ai) |
| \`reciprocity_time_first_interrupted\` | r^(4bi) |

Each measures the same quantity as its continuous counterpart but considers only reverse-dyad events that occurred *since* the most recent same-direction event. Firing (s, r) closes the reciprocity cycle for dyad (s, r) and resets its interrupted state.

## Test plan

- [x] \`tests/testthat/test-interrupted-reciprocity.R\` (9 blocks, 170 assertions): brute-force equality, the count ≤ continuous-count invariant, a hand-crafted reset scenario, sim ↔ post-hoc parity on all 5 variants, half_life error path, tau-leap, and GAM sign-recovery.
- [x] Parity suite extended (\`test-sim-vs-posthoc-parity.R\`): a new block covers the 5 interrupted stats so the cross-implementation guard continues to be authoritative.
- [x] Full suite: 1887 PASS / 0 FAIL.
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (all pre-existing).