### PR TITLE
Add cyclic / balance exp_decay stats (paper c/sb/rb^(5c))

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -311,10 +311,13 @@ compute_endogenous_features <- function(
     "transitivity_time_recent", "transitivity_time_first",
     "transitivity_time_recent_ordered", "transitivity_time_first_ordered",
     "cyclic_binary", "cyclic_count", "cyclic_time_recent", "cyclic_time_first",
+    "cyclic_exp_decay",
     "sending_balance_binary", "sending_balance_count",
     "sending_balance_time_recent", "sending_balance_time_first",
+    "sending_balance_exp_decay",
     "receiving_balance_binary", "receiving_balance_count",
-    "receiving_balance_time_recent", "receiving_balance_time_first"
+    "receiving_balance_time_recent", "receiving_balance_time_first",
+    "receiving_balance_exp_decay"
   )
   bad <- setdiff(stats, allowed)
   if (length(bad)) {
@@ -326,7 +329,10 @@ compute_endogenous_features <- function(
 
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
                        "transitivity_exp_decay_ordered",
-                       "reciprocity_exp_decay_interrupted")
+                       "reciprocity_exp_decay_interrupted",
+                       "cyclic_exp_decay",
+                       "sending_balance_exp_decay",
+                       "receiving_balance_exp_decay")
   if (any(exp_decay_stats %in% stats) &&
       (is.null(half_life) || !is.numeric(half_life) || half_life <= 0)) {
     stop("`half_life` must be a positive number when ",
@@ -353,11 +359,14 @@ compute_endogenous_features <- function(
                    "transitivity_time_recent_ordered",
                    "transitivity_time_first_ordered")
   cyc_names   <- c("cyclic_binary", "cyclic_count",
-                   "cyclic_time_recent", "cyclic_time_first")
+                   "cyclic_time_recent", "cyclic_time_first",
+                   "cyclic_exp_decay")
   sb_names    <- c("sending_balance_binary", "sending_balance_count",
-                   "sending_balance_time_recent", "sending_balance_time_first")
+                   "sending_balance_time_recent", "sending_balance_time_first",
+                   "sending_balance_exp_decay")
   rb_names    <- c("receiving_balance_binary", "receiving_balance_count",
-                   "receiving_balance_time_recent", "receiving_balance_time_first")
+                   "receiving_balance_time_recent", "receiving_balance_time_first",
+                   "receiving_balance_exp_decay")
   need_triadic <- any(c(trans_names, cyc_names, sb_names, rb_names) %in% stats)
 
   # --- Tracking data structures ---
@@ -409,8 +418,9 @@ compute_endogenous_features <- function(
                  "reciprocity_count", "reciprocity_exp_decay",
                  "transitivity_count", "transitivity_count_ordered",
                  "transitivity_exp_decay", "transitivity_exp_decay_ordered",
-                 "cyclic_count", "sending_balance_count",
-                 "receiving_balance_count",
+                 "cyclic_count", "cyclic_exp_decay",
+                 "sending_balance_count", "sending_balance_exp_decay",
+                 "receiving_balance_count", "receiving_balance_exp_decay",
                  "reciprocity_count_interrupted",
                  "reciprocity_exp_decay_interrupted")
   for (stat in stats) {

--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -49,6 +49,15 @@
 #'       \code{"transitivity_exp_decay"} but only counts \emph{ordered}
 #'       two-paths (s → k strictly before k → r), definition
 #'       \eqn{t^{(6c)}}.  Requires \code{half_life}.
+#'     \item \code{"cyclic_exp_decay"} — exp-decayed sum over cyclic
+#'       two-paths \eqn{r \to k \to s} (paper \eqn{c^{(5c)}}).  Requires
+#'       \code{half_life}.
+#'     \item \code{"sending_balance_exp_decay"} — exp-decayed sum over
+#'       shared-target two-paths \eqn{s \to k,\ r \to k} (paper
+#'       \eqn{sb^{(5c)}}).  Requires \code{half_life}.
+#'     \item \code{"receiving_balance_exp_decay"} — exp-decayed sum over
+#'       shared-source two-paths \eqn{k \to s,\ k \to r} (paper
+#'       \eqn{rb^{(5c)}}).  Requires \code{half_life}.
 #'     \item \code{"reciprocity_time_recent"} — elapsed time since the most
 #'       recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 #'       \code{0} for dyads whose reverse has never fired (rather than the
@@ -349,7 +358,10 @@ simulate_relational_events <- function(
                      "transitivity_time_recent_ordered",
                      "transitivity_time_first_ordered",
                      "transitivity_exp_decay",
-                     "transitivity_exp_decay_ordered")
+                     "transitivity_exp_decay_ordered",
+                     "cyclic_exp_decay",
+                     "sending_balance_exp_decay",
+                     "receiving_balance_exp_decay")
   ordered_stats <- c("transitivity_count_ordered",
                      "transitivity_binary_ordered",
                      "transitivity_time_recent_ordered",
@@ -357,7 +369,10 @@ simulate_relational_events <- function(
                      "transitivity_exp_decay_ordered")
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
                        "transitivity_exp_decay_ordered",
-                       "reciprocity_exp_decay_interrupted")
+                       "reciprocity_exp_decay_interrupted",
+                       "cyclic_exp_decay",
+                       "sending_balance_exp_decay",
+                       "receiving_balance_exp_decay")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
                             degree_stats, network_stats)
@@ -575,6 +590,13 @@ simulate_relational_events <- function(
   # Map each generative "two-path timing" stat to (family, is_first) so the
   # state-update sweep can be derived in a single helper instead of branching
   # per stat name in two places (Gillespie + tau-leap inner loops).
+  exp_decay_family_lookup <- list(
+    transitivity_exp_decay      = "transitivity",
+    cyclic_exp_decay            = "cyclic",
+    sending_balance_exp_decay   = "sending_balance",
+    receiving_balance_exp_decay = "receiving_balance"
+  )
+
   two_path_time_lookup <- list(
     transitivity_time_recent      = list(family = "transitivity",      first = FALSE),
     transitivity_time_first       = list(family = "transitivity",      first = TRUE),
@@ -770,6 +792,9 @@ simulate_relational_events <- function(
         "transitivity_time_first_ordered" = time_elapsed_or_zero(endo_state[[st]]),
         "transitivity_exp_decay"          = endo_state[[st]],
         "transitivity_exp_decay_ordered"  = endo_state[[st]],
+        "cyclic_exp_decay"                = endo_state[[st]],
+        "sending_balance_exp_decay"       = endo_state[[st]],
+        "receiving_balance_exp_decay"     = endo_state[[st]],
         "reciprocity_count_interrupted"        = endo_state[[st]],
         "reciprocity_binary_interrupted"       = endo_state[[st]],
         "reciprocity_exp_decay_interrupted"    = endo_state[[st]],
@@ -1059,9 +1084,10 @@ simulate_relational_events <- function(
                     endo_state[[st]] <- apply_time_writes(
                       endo_state[[st]], writes, ev_times[k], info$first)
                   }
-                } else if (st == "transitivity_exp_decay") {
+                } else if (!is.null(exp_decay_family_lookup[[st]])) {
                   if (adj_state[s_k, r_k] == 0) {
-                    writes <- two_path_writes("transitivity", s_k, r_k, adj_state)
+                    fam <- exp_decay_family_lookup[[st]]
+                    writes <- two_path_writes(fam, s_k, r_k, adj_state)
                     if (nrow(writes)) {
                       endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
                     }
@@ -1270,13 +1296,14 @@ simulate_relational_events <- function(
             endo_state[[st]] <- apply_time_writes(
               endo_state[[st]], writes, current_time, info$first)
           }
-        } else if (st == "transitivity_exp_decay") {
-          # Unordered exp-decay: each newly-formed two-path contributes
-          # +1 (decay state was just attenuated to current_time, so a
-          # fresh contribution of weight exp(0) = 1 is correct). Same
-          # first-fire gate as the timing stats.
+        } else if (!is.null(exp_decay_family_lookup[[st]])) {
+          # Unordered exp-decay for any closure family: each newly-formed
+          # two-path contributes +1 (decay state was just attenuated to
+          # current_time, so a fresh contribution of weight exp(0) = 1 is
+          # correct). Same first-fire gate as the timing stats.
           if (adj_state[s_idx, r_idx] == 0) {
-            writes <- two_path_writes("transitivity", s_idx, r_idx, adj_state)
+            fam <- exp_decay_family_lookup[[st]]
+            writes <- two_path_writes(fam, s_idx, r_idx, adj_state)
             if (nrow(writes)) {
               endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
             }

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -86,6 +86,15 @@ Juozaitienė & Wit, 2024). Requires \code{half_life}.
 \code{"transitivity_exp_decay"} but only counts \emph{ordered}
 two-paths (s → k strictly before k → r), definition
 \eqn{t^{(6c)}}.  Requires \code{half_life}.
+\item \code{"cyclic_exp_decay"} — exp-decayed sum over cyclic
+two-paths \eqn{r \to k \to s} (paper \eqn{c^{(5c)}}).  Requires
+\code{half_life}.
+\item \code{"sending_balance_exp_decay"} — exp-decayed sum over
+shared-target two-paths \eqn{s \to k,\ r \to k} (paper
+\eqn{sb^{(5c)}}).  Requires \code{half_life}.
+\item \code{"receiving_balance_exp_decay"} — exp-decayed sum over
+shared-source two-paths \eqn{k \to s,\ k \to r} (paper
+\eqn{rb^{(5c)}}).  Requires \code{half_life}.
 \item \code{"reciprocity_time_recent"} — elapsed time since the most
 recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 \code{0} for dyads whose reverse has never fired (rather than the

--- a/tests/testthat/test-cyclic-balance-exp-decay.R
+++ b/tests/testthat/test-cyclic-balance-exp-decay.R
@@ -1,0 +1,165 @@
+# test-cyclic-balance-exp-decay.R
+# Coverage for the three new generative exp-decay stats:
+#   cyclic_exp_decay            (paper c^(5c))
+#   sending_balance_exp_decay   (paper sb^(5c))
+#   receiving_balance_exp_decay (paper rb^(5c))
+#
+# Each family follows the same template as transitivity_exp_decay
+# (paper t^(5c)): for each intermediary k, the relevant two-path
+# contributes a single exp-decayed term centred on its formation
+# time (= time the second of its two legs is first observed).
+
+# Brute-force expected exp_decay at a given (s, r) and time, for a
+# specified family. `legs(prior, which, s, r, k)` returns the mask
+# selecting all rows of `prior` that are the requested leg (A or B)
+# of the family's two-path between s and r through k.
+expected_decay <- function(prior, s, r, t_now, half_life, actors,
+                            legs_fn) {
+  if (!nrow(prior)) return(0)
+  decay_rate <- log(2) / half_life
+  out <- 0
+  for (k in actors) {
+    if (k == s || k == r) next
+    legA <- prior$time[legs_fn(prior, "A", s, r, k)]
+    legB <- prior$time[legs_fn(prior, "B", s, r, k)]
+    if (!length(legA) || !length(legB)) next
+    formation <- max(min(legA), min(legB))
+    out <- out + exp(-(t_now - formation) * decay_rate)
+  }
+  out
+}
+
+families <- list(
+  cyclic = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == r & prior$receiver == k
+    else              prior$sender == k & prior$receiver == s
+  },
+  sending_balance = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == s & prior$receiver == k
+    else              prior$sender == r & prior$receiver == k
+  },
+  receiving_balance = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == k & prior$receiver == s
+    else              prior$sender == k & prior$receiver == r
+  })
+
+run_check <- function(family_name, stat_name, seed, n_events = 25,
+                       n_actors = 5, half_life = 0.7) {
+  set.seed(seed)
+  ev <- simulate_relational_events(
+    n_events = n_events,
+    senders = LETTERS[1:n_actors], receivers = LETTERS[1:n_actors],
+    baseline_rate = 3,
+    endogenous_stats = stat_name,
+    endogenous_effects = 0,
+    half_life = half_life)
+  actors <- LETTERS[1:n_actors]
+  legs_fn <- families[[family_name]]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    exp_val <- expected_decay(prior, ev$sender[i], ev$receiver[i],
+                              ev$time[i], half_life, actors, legs_fn)
+    expect_equal(ev[[stat_name]][i], exp_val, tolerance = 1e-9,
+                 info = paste(family_name, "row", i))
+  }
+}
+
+test_that("cyclic_exp_decay matches brute force on small one-mode runs", {
+  run_check("cyclic", "cyclic_exp_decay", seed = 51)
+})
+
+test_that("sending_balance_exp_decay matches brute force on small one-mode runs", {
+  run_check("sending_balance", "sending_balance_exp_decay", seed = 52)
+})
+
+test_that("receiving_balance_exp_decay matches brute force on small one-mode runs", {
+  run_check("receiving_balance", "receiving_balance_exp_decay", seed = 53)
+})
+
+test_that("each closure family's exp_decay is 0 wherever its count is 0", {
+  set.seed(54)
+  ev <- simulate_relational_events(
+    n_events = 25,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("cyclic_count", "cyclic_exp_decay",
+                         "sending_balance_count", "sending_balance_exp_decay",
+                         "receiving_balance_count", "receiving_balance_exp_decay"),
+    endogenous_effects = c(cyclic_count = 0, cyclic_exp_decay = 0,
+                            sending_balance_count = 0,
+                            sending_balance_exp_decay = 0,
+                            receiving_balance_count = 0,
+                            receiving_balance_exp_decay = 0),
+    half_life = 1)
+  expect_true(all(ev$cyclic_exp_decay[ev$cyclic_count == 0] == 0))
+  expect_true(all(ev$sending_balance_exp_decay[ev$sending_balance_count == 0] == 0))
+  expect_true(all(ev$receiving_balance_exp_decay[ev$receiving_balance_count == 0] == 0))
+})
+
+test_that("half_life is required for each new exp_decay stat", {
+  for (st in c("cyclic_exp_decay", "sending_balance_exp_decay",
+               "receiving_balance_exp_decay")) {
+    expect_error(
+      simulate_relational_events(
+        n_events = 5,
+        senders = LETTERS[1:3], receivers = LETTERS[1:3],
+        endogenous_stats = st,
+        endogenous_effects = 0),
+      "half_life",
+      info = st)
+  }
+})
+
+test_that("each new exp_decay stat errors on bipartite settings", {
+  for (st in c("cyclic_exp_decay", "sending_balance_exp_decay",
+               "receiving_balance_exp_decay")) {
+    expect_error(
+      simulate_relational_events(
+        n_events = 5,
+        senders = c("a", "b"), receivers = c("x", "y", "z"),
+        endogenous_stats = st,
+        endogenous_effects = 0.5,
+        half_life = 1),
+      "one-mode",
+      info = st)
+  }
+})
+
+test_that("each new exp_decay stat runs under tau-leap and stays non-negative", {
+  set.seed(55)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = c("cyclic_exp_decay", "sending_balance_exp_decay",
+                         "receiving_balance_exp_decay"),
+    endogenous_effects = c(cyclic_exp_decay = 0,
+                            sending_balance_exp_decay = 0,
+                            receiving_balance_exp_decay = 0),
+    half_life = 1,
+    method = "tau_leap", tau = 0.02)
+  expect_true(all(ev$cyclic_exp_decay >= 0))
+  expect_true(all(ev$sending_balance_exp_decay >= 0))
+  expect_true(all(ev$receiving_balance_exp_decay >= 0))
+})
+
+test_that("all four closure-family exp_decay stats compose in one call", {
+  set.seed(56)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_exp_decay",
+                         "cyclic_exp_decay",
+                         "sending_balance_exp_decay",
+                         "receiving_balance_exp_decay"),
+    endogenous_effects = c(transitivity_exp_decay = 0,
+                            cyclic_exp_decay = 0,
+                            sending_balance_exp_decay = 0,
+                            receiving_balance_exp_decay = 0),
+    half_life = 1)
+  for (st in c("transitivity_exp_decay", "cyclic_exp_decay",
+               "sending_balance_exp_decay", "receiving_balance_exp_decay")) {
+    expect_true(all(ev[[st]] >= 0), info = st)
+  }
+})

--- a/tests/testthat/test-sim-vs-posthoc-parity.R
+++ b/tests/testthat/test-sim-vs-posthoc-parity.R
@@ -82,22 +82,25 @@ test_that("simulator and post-hoc agree on transitivity ordered stats", {
 
 test_that("simulator and post-hoc agree on cyclic stats", {
   stats <- c("cyclic_binary", "cyclic_count",
-             "cyclic_time_recent", "cyclic_time_first")
-  out <- sim_vs_posthoc(stats, seed = 104)
+             "cyclic_time_recent", "cyclic_time_first",
+             "cyclic_exp_decay")
+  out <- sim_vs_posthoc(stats, seed = 104, half_life = 1)
   for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
 })
 
 test_that("simulator and post-hoc agree on sending_balance stats", {
   stats <- c("sending_balance_binary", "sending_balance_count",
-             "sending_balance_time_recent", "sending_balance_time_first")
-  out <- sim_vs_posthoc(stats, seed = 105)
+             "sending_balance_time_recent", "sending_balance_time_first",
+             "sending_balance_exp_decay")
+  out <- sim_vs_posthoc(stats, seed = 105, half_life = 1)
   for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
 })
 
 test_that("simulator and post-hoc agree on receiving_balance stats", {
   stats <- c("receiving_balance_binary", "receiving_balance_count",
-             "receiving_balance_time_recent", "receiving_balance_time_first")
-  out <- sim_vs_posthoc(stats, seed = 106)
+             "receiving_balance_time_recent", "receiving_balance_time_first",
+             "receiving_balance_exp_decay")
+  out <- sim_vs_posthoc(stats, seed = 106, half_life = 1)
   for (st in stats) expect_columns_match(out$sim, out$posthoc, st)
 })
 


### PR DESCRIPTION
## Summary

Adds three exp-decay statistics from the closure family that were missing from the simulator and post-hoc:

| stat | paper |
|---|---|
| \`cyclic_exp_decay\` | c^(5c) |
| \`sending_balance_exp_decay\` | sb^(5c) |
| \`receiving_balance_exp_decay\` | rb^(5c) |

Empirically motivated — Juozaitienė & Wit (2024) Table 3 selects c^(5c) on Enron, rb^(5c) on Enron *and* Classroom.

## Implementation

- Generalised the transitivity_exp_decay branch into a single dispatch on \`exp_decay_family_lookup\` (which maps each \`*_exp_decay\` stat name to its family in \`two_path_writes()\`). Same pattern for the unordered timing stats (\`two_path_time_lookup\`) was already in place.
- \`apply_exp_decay()\` already iterates over every active exp_decay state, so the new stats inherit the shared decay rate for free.
- Post-hoc's \`compute_triadic\` already supports the \`prefix_exp_decay\` slot via the existing \`exp_sum\` aggregator; only the caller-side allowed list and family-name groupings needed updating.

## Test plan

- [x] \`test-cyclic-balance-exp-decay.R\` (7 blocks, 91 assertions) — brute-force equality, zero-when-count-zero, half_life required, bipartite raises, tau-leap, all four families composing in one call.
- [x] \`test-sim-vs-posthoc-parity.R\` extended — the existing cyclic / sb / rb blocks now also include the new \`*_exp_decay\` stat. All 26 closure-family stats are directly cross-validated.
- [x] Full suite: 1987 PASS / 0 FAIL.
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (all pre-existing).