### PR TITLE
Add interrupted timing stats for the triadic closure family

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -58,6 +58,23 @@
 #'     \item \code{"receiving_balance_exp_decay"} — exp-decayed sum over
 #'       shared-source two-paths \eqn{k \to s,\ k \to r} (paper
 #'       \eqn{rb^{(5c)}}).  Requires \code{half_life}.
+#'     \item \code{"transitivity_time_recent_interrupted"} /
+#'       \code{"transitivity_time_first_interrupted"} —
+#'       \emph{interrupted} timing variants of the transitivity family
+#'       (paper \eqn{t^{(7ai)} / t^{(7bi)}}). Every \eqn{s \to r}
+#'       event resets the firing dyad's interrupted state to
+#'       \code{NA}, so the value at \eqn{(s, r)} reflects the most
+#'       recent / first two-path \eqn{s \to k \to r} formed
+#'       \emph{since the most recent closure event}.
+#'     \item \code{"cyclic_time_recent_interrupted"} /
+#'       \code{"cyclic_time_first_interrupted"} — same pattern for
+#'       cyclic two-paths \eqn{r \to k \to s}.
+#'     \item \code{"sending_balance_time_recent_interrupted"} /
+#'       \code{"sending_balance_time_first_interrupted"} — same
+#'       pattern for shared-target two-paths.
+#'     \item \code{"receiving_balance_time_recent_interrupted"} /
+#'       \code{"receiving_balance_time_first_interrupted"} — same
+#'       pattern for shared-source two-paths.
 #'     \item \code{"reciprocity_time_recent"} — elapsed time since the most
 #'       recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 #'       \code{0} for dyads whose reverse has never fired (rather than the
@@ -361,7 +378,15 @@ simulate_relational_events <- function(
                      "transitivity_exp_decay_ordered",
                      "cyclic_exp_decay",
                      "sending_balance_exp_decay",
-                     "receiving_balance_exp_decay")
+                     "receiving_balance_exp_decay",
+                     "transitivity_time_recent_interrupted",
+                     "transitivity_time_first_interrupted",
+                     "cyclic_time_recent_interrupted",
+                     "cyclic_time_first_interrupted",
+                     "sending_balance_time_recent_interrupted",
+                     "sending_balance_time_first_interrupted",
+                     "receiving_balance_time_recent_interrupted",
+                     "receiving_balance_time_first_interrupted")
   ordered_stats <- c("transitivity_count_ordered",
                      "transitivity_binary_ordered",
                      "transitivity_time_recent_ordered",
@@ -528,7 +553,15 @@ simulate_relational_events <- function(
                             "transitivity_time_recent_ordered",
                             "transitivity_time_first_ordered",
                             "reciprocity_time_recent_interrupted",
-                            "reciprocity_time_first_interrupted")) {
+                            "reciprocity_time_first_interrupted",
+                            "transitivity_time_recent_interrupted",
+                            "transitivity_time_first_interrupted",
+                            "cyclic_time_recent_interrupted",
+                            "cyclic_time_first_interrupted",
+                            "sending_balance_time_recent_interrupted",
+                            "sending_balance_time_first_interrupted",
+                            "receiving_balance_time_recent_interrupted",
+                            "receiving_balance_time_first_interrupted")) {
         # NA marks "the relevant past event (reverse dyad, or two-path)
         # has never happened". Replaced with 0 in the score / output
         # matrices so the rate computation stays numeric (see
@@ -598,13 +631,21 @@ simulate_relational_events <- function(
   )
 
   two_path_time_lookup <- list(
-    transitivity_time_recent      = list(family = "transitivity",      first = FALSE),
-    transitivity_time_first       = list(family = "transitivity",      first = TRUE),
-    cyclic_time_recent            = list(family = "cyclic",            first = FALSE),
-    cyclic_time_first             = list(family = "cyclic",            first = TRUE),
-    sending_balance_time_recent   = list(family = "sending_balance",   first = FALSE),
-    sending_balance_time_first    = list(family = "sending_balance",   first = TRUE),
-    receiving_balance_time_recent = list(family = "receiving_balance", first = FALSE),
+    transitivity_time_recent      = list(family = "transitivity",      first = FALSE, interrupted = FALSE),
+    transitivity_time_first       = list(family = "transitivity",      first = TRUE,  interrupted = FALSE),
+    cyclic_time_recent            = list(family = "cyclic",            first = FALSE, interrupted = FALSE),
+    cyclic_time_first             = list(family = "cyclic",            first = TRUE,  interrupted = FALSE),
+    sending_balance_time_recent   = list(family = "sending_balance",   first = FALSE, interrupted = FALSE),
+    sending_balance_time_first    = list(family = "sending_balance",   first = TRUE,  interrupted = FALSE),
+    receiving_balance_time_recent = list(family = "receiving_balance", first = FALSE, interrupted = FALSE),
+    transitivity_time_recent_interrupted      = list(family = "transitivity",      first = FALSE, interrupted = TRUE),
+    transitivity_time_first_interrupted       = list(family = "transitivity",      first = TRUE,  interrupted = TRUE),
+    cyclic_time_recent_interrupted            = list(family = "cyclic",            first = FALSE, interrupted = TRUE),
+    cyclic_time_first_interrupted             = list(family = "cyclic",            first = TRUE,  interrupted = TRUE),
+    sending_balance_time_recent_interrupted   = list(family = "sending_balance",   first = FALSE, interrupted = TRUE),
+    sending_balance_time_first_interrupted    = list(family = "sending_balance",   first = TRUE,  interrupted = TRUE),
+    receiving_balance_time_recent_interrupted = list(family = "receiving_balance", first = FALSE, interrupted = TRUE),
+    receiving_balance_time_first_interrupted  = list(family = "receiving_balance", first = TRUE,  interrupted = TRUE),
     receiving_balance_time_first  = list(family = "receiving_balance", first = TRUE)
   )
 
@@ -800,6 +841,14 @@ simulate_relational_events <- function(
         "reciprocity_exp_decay_interrupted"    = endo_state[[st]],
         "reciprocity_time_recent_interrupted"  = time_elapsed_or_zero(endo_state[[st]]),
         "reciprocity_time_first_interrupted"   = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_time_recent_interrupted"     = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_time_first_interrupted"      = time_elapsed_or_zero(endo_state[[st]]),
+        "cyclic_time_recent_interrupted"           = time_elapsed_or_zero(endo_state[[st]]),
+        "cyclic_time_first_interrupted"            = time_elapsed_or_zero(endo_state[[st]]),
+        "sending_balance_time_recent_interrupted"  = time_elapsed_or_zero(endo_state[[st]]),
+        "sending_balance_time_first_interrupted"   = time_elapsed_or_zero(endo_state[[st]]),
+        "receiving_balance_time_recent_interrupted"= time_elapsed_or_zero(endo_state[[st]]),
+        "receiving_balance_time_first_interrupted" = time_elapsed_or_zero(endo_state[[st]]),
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -954,7 +1003,15 @@ simulate_relational_events <- function(
                        "transitivity_time_recent_ordered",
                        "transitivity_time_first_ordered",
                        "reciprocity_time_recent_interrupted",
-                       "reciprocity_time_first_interrupted")) {
+                       "reciprocity_time_first_interrupted",
+                       "transitivity_time_recent_interrupted",
+                       "transitivity_time_first_interrupted",
+                       "cyclic_time_recent_interrupted",
+                       "cyclic_time_first_interrupted",
+                       "sending_balance_time_recent_interrupted",
+                       "sending_balance_time_first_interrupted",
+                       "receiving_balance_time_recent_interrupted",
+                       "receiving_balance_time_first_interrupted")) {
             if (ts %in% endogenous_stats) {
               snap[[ts]] <- endo_state[[ts]]
             }
@@ -1078,11 +1135,14 @@ simulate_relational_events <- function(
                   }
                   endo_state[[st]][s_k, r_k] <- NA_real_
                 } else if (!is.null(two_path_time_lookup[[st]])) {
+                  info <- two_path_time_lookup[[st]]
                   if (adj_state[s_k, r_k] == 0) {
-                    info <- two_path_time_lookup[[st]]
                     writes <- two_path_writes(info$family, s_k, r_k, adj_state)
                     endo_state[[st]] <- apply_time_writes(
                       endo_state[[st]], writes, ev_times[k], info$first)
+                  }
+                  if (isTRUE(info$interrupted)) {
+                    endo_state[[st]][s_k, r_k] <- NA_real_
                   }
                 } else if (!is.null(exp_decay_family_lookup[[st]])) {
                   if (adj_state[s_k, r_k] == 0) {
@@ -1290,11 +1350,20 @@ simulate_relational_events <- function(
           # new two-paths. So only sweep when this is the first
           # occurrence of dyad (s_idx, r_idx). The per-family geometry
           # is encapsulated in two_path_writes().
+          info <- two_path_time_lookup[[st]]
           if (adj_state[s_idx, r_idx] == 0) {
-            info <- two_path_time_lookup[[st]]
             writes <- two_path_writes(info$family, s_idx, r_idx, adj_state)
             endo_state[[st]] <- apply_time_writes(
               endo_state[[st]], writes, current_time, info$first)
+          }
+          # Interrupted variant: every (s, r) event closes any open
+          # triad rooted at dyad (s, r), so reset the firing dyad's
+          # own state to NA regardless of whether new formations
+          # happened above. The writes from apply_time_writes never
+          # target the firing dyad itself, so this reset is safe to
+          # apply after the writes block.
+          if (isTRUE(info$interrupted)) {
+            endo_state[[st]][s_idx, r_idx] <- NA_real_
           }
         } else if (!is.null(exp_decay_family_lookup[[st]])) {
           # Unordered exp-decay for any closure family: each newly-formed

--- a/man/simulate_relational_events.Rd
+++ b/man/simulate_relational_events.Rd
@@ -95,6 +95,23 @@ shared-target two-paths \eqn{s \to k,\ r \to k} (paper
 \item \code{"receiving_balance_exp_decay"} — exp-decayed sum over
 shared-source two-paths \eqn{k \to s,\ k \to r} (paper
 \eqn{rb^{(5c)}}).  Requires \code{half_life}.
+\item \code{"transitivity_time_recent_interrupted"} /
+\code{"transitivity_time_first_interrupted"} —
+\emph{interrupted} timing variants of the transitivity family
+(paper \eqn{t^{(7ai)} / t^{(7bi)}}). Every \eqn{s \to r}
+event resets the firing dyad's interrupted state to
+\code{NA}, so the value at \eqn{(s, r)} reflects the most
+recent / first two-path \eqn{s \to k \to r} formed
+\emph{since the most recent closure event}.
+\item \code{"cyclic_time_recent_interrupted"} /
+\code{"cyclic_time_first_interrupted"} — same pattern for
+cyclic two-paths \eqn{r \to k \to s}.
+\item \code{"sending_balance_time_recent_interrupted"} /
+\code{"sending_balance_time_first_interrupted"} — same
+pattern for shared-target two-paths.
+\item \code{"receiving_balance_time_recent_interrupted"} /
+\code{"receiving_balance_time_first_interrupted"} — same
+pattern for shared-source two-paths.
 \item \code{"reciprocity_time_recent"} — elapsed time since the most
 recent reverse-dyad event \eqn{t - t_{\text{recent}}(r,s)}; reports
 \code{0} for dyads whose reverse has never fired (rather than the

--- a/tests/testthat/test-interrupted-triadic-timing.R
+++ b/tests/testthat/test-interrupted-triadic-timing.R
@@ -1,0 +1,227 @@
+# test-interrupted-triadic-timing.R
+# Coverage for the eight interrupted triadic-family timing stats:
+#   transitivity_time_recent_interrupted, transitivity_time_first_interrupted
+#   cyclic_time_recent_interrupted,       cyclic_time_first_interrupted
+#   sending_balance_time_recent_interrupted, _time_first_interrupted
+#   receiving_balance_time_recent_interrupted, _time_first_interrupted
+#
+# An interrupted variant has the same formation-time semantics as its
+# unordered counterpart but resets the firing dyad's state to NA on
+# every (s, r) event (= closure event; paper §2.2.2).
+
+# Family-specific leg masks for the brute-force enumerator.
+fam_legs <- list(
+  transitivity = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == s & prior$receiver == k
+    else              prior$sender == k & prior$receiver == r
+  },
+  cyclic = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == r & prior$receiver == k
+    else              prior$sender == k & prior$receiver == s
+  },
+  sending_balance = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == s & prior$receiver == k
+    else              prior$sender == r & prior$receiver == k
+  },
+  receiving_balance = function(prior, which, s, r, k) {
+    if (which == "A") prior$sender == k & prior$receiver == s
+    else              prior$sender == k & prior$receiver == r
+  })
+
+# Brute-force expected interrupted timing value at (s, r, t_now) given
+# the prior event log. `which = "recent"` returns t_now - max formation
+# time among formations strictly after the most recent (s, r) event;
+# `which = "first"` returns t_now - min of those formations. Returns 0
+# if there are no qualifying formations (matches the simulator's
+# NA -> 0 convention).
+brute_force_int_triadic <- function(prior, s, r, t_now, family,
+                                     which = c("recent", "first"),
+                                     actors) {
+  which <- match.arg(which)
+  legs_fn <- fam_legs[[family]]
+  # Most recent (s, r) event before t_now -> the most recent closure.
+  closures <- prior$time[prior$sender == s & prior$receiver == r]
+  t_close <- if (length(closures)) max(closures) else -Inf
+  formations <- numeric(0)
+  for (k in actors) {
+    if (k == s || k == r) next
+    legA <- prior$time[legs_fn(prior, "A", s, r, k)]
+    legB <- prior$time[legs_fn(prior, "B", s, r, k)]
+    if (!length(legA) || !length(legB)) next
+    formation_k <- max(min(legA), min(legB))
+    if (formation_k > t_close) formations <- c(formations, formation_k)
+  }
+  if (!length(formations)) return(0)
+  if (which == "recent") t_now - max(formations)
+  else                    t_now - min(formations)
+}
+
+run_check <- function(family, seed, n_events = 25, n_actors = 5) {
+  recent_nm <- paste0(family, "_time_recent_interrupted")
+  first_nm  <- paste0(family, "_time_first_interrupted")
+  set.seed(seed)
+  ev <- simulate_relational_events(
+    n_events = n_events,
+    senders = LETTERS[1:n_actors], receivers = LETTERS[1:n_actors],
+    baseline_rate = 3,
+    endogenous_stats = c(recent_nm, first_nm),
+    endogenous_effects = setNames(c(0, 0), c(recent_nm, first_nm)))
+  actors <- LETTERS[1:n_actors]
+  for (i in seq_len(nrow(ev))) {
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    exp_recent <- brute_force_int_triadic(
+      prior, ev$sender[i], ev$receiver[i], ev$time[i], family, "recent", actors)
+    exp_first  <- brute_force_int_triadic(
+      prior, ev$sender[i], ev$receiver[i], ev$time[i], family, "first",  actors)
+    expect_equal(ev[[recent_nm]][i], exp_recent, tolerance = 1e-9,
+                 info = paste(family, "row", i, "recent"))
+    expect_equal(ev[[first_nm]][i],  exp_first,  tolerance = 1e-9,
+                 info = paste(family, "row", i, "first"))
+  }
+}
+
+test_that("transitivity interrupted timing matches brute force", {
+  run_check("transitivity", seed = 71)
+})
+
+test_that("cyclic interrupted timing matches brute force", {
+  run_check("cyclic", seed = 72)
+})
+
+test_that("sending_balance interrupted timing matches brute force", {
+  run_check("sending_balance", seed = 73)
+})
+
+test_that("receiving_balance interrupted timing matches brute force", {
+  run_check("receiving_balance", seed = 74)
+})
+
+test_that("interrupted state is 0 immediately after a closure event", {
+  # Hand-crafted: A->B opens an s->k->r chain via B; then A->C closes
+  # any open triad rooted at (A, C). Re-firing of any leg must NOT
+  # revive the interrupted state.
+  set.seed(75)
+  ev <- simulate_relational_events(
+    n_events = 50,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_time_recent_interrupted",
+                         "transitivity_time_recent"),
+    endogenous_effects = c(transitivity_time_recent_interrupted = 0,
+                            transitivity_time_recent = 0))
+  for (i in seq_len(nrow(ev))) {
+    # Check: if the dyad has fired before row i with any formation
+    # happening before the most recent prior firing of the same dyad,
+    # the interrupted value must be 0.
+    prior <- ev[seq_len(i - 1L), , drop = FALSE]
+    prev_same <- prior$time[prior$sender == ev$sender[i] &
+                              prior$receiver == ev$receiver[i]]
+    if (length(prev_same)) {
+      # Was every formation of two-paths s->k->r before max(prev_same)?
+      # If so, interrupted must be 0.
+      t_close <- max(prev_same)
+      any_post <- FALSE
+      for (k in LETTERS[1:5]) {
+        if (k == ev$sender[i] || k == ev$receiver[i]) next
+        leg1 <- prior$time[prior$sender == ev$sender[i] & prior$receiver == k]
+        leg2 <- prior$time[prior$sender == k & prior$receiver == ev$receiver[i]]
+        if (!length(leg1) || !length(leg2)) next
+        if (max(min(leg1), min(leg2)) > t_close) { any_post <- TRUE; break }
+      }
+      if (!any_post) {
+        expect_equal(ev$transitivity_time_recent_interrupted[i], 0,
+                     info = paste("row", i, "must be 0 post-closure"))
+      }
+    }
+  }
+})
+
+test_that("first >= recent on every row for every interrupted triadic family", {
+  for (fam in c("transitivity", "cyclic",
+                "sending_balance", "receiving_balance")) {
+    set.seed(80 + match(fam, c("transitivity", "cyclic",
+                                 "sending_balance", "receiving_balance")))
+    rec <- paste0(fam, "_time_recent_interrupted")
+    fst <- paste0(fam, "_time_first_interrupted")
+    ev <- simulate_relational_events(
+      n_events = 30,
+      senders = LETTERS[1:5], receivers = LETTERS[1:5],
+      baseline_rate = 3,
+      endogenous_stats = c(rec, fst),
+      endogenous_effects = setNames(c(0, 0), c(rec, fst)))
+    expect_true(all(ev[[fst]] >= ev[[rec]]),
+                info = paste(fam, "first must be >= recent"))
+  }
+})
+
+test_that("interrupted variants are <= their continuous counterparts", {
+  set.seed(91)
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 3,
+    endogenous_stats = c("transitivity_time_recent",
+                         "transitivity_time_recent_interrupted",
+                         "cyclic_time_recent",
+                         "cyclic_time_recent_interrupted",
+                         "sending_balance_time_recent",
+                         "sending_balance_time_recent_interrupted",
+                         "receiving_balance_time_recent",
+                         "receiving_balance_time_recent_interrupted"),
+    endogenous_effects = setNames(rep(0, 8),
+                                    c("transitivity_time_recent",
+                                      "transitivity_time_recent_interrupted",
+                                      "cyclic_time_recent",
+                                      "cyclic_time_recent_interrupted",
+                                      "sending_balance_time_recent",
+                                      "sending_balance_time_recent_interrupted",
+                                      "receiving_balance_time_recent",
+                                      "receiving_balance_time_recent_interrupted")))
+  for (fam in c("transitivity", "cyclic",
+                "sending_balance", "receiving_balance")) {
+    c_nm <- paste0(fam, "_time_recent")
+    i_nm <- paste0(fam, "_time_recent_interrupted")
+    expect_true(all(ev[[i_nm]] <= ev[[c_nm]] + 1e-9),
+                info = paste(fam, "interrupted_recent <= continuous_recent"))
+  }
+})
+
+test_that("all interrupted triadic timing stats error on bipartite", {
+  for (st in c("transitivity_time_recent_interrupted",
+               "transitivity_time_first_interrupted",
+               "cyclic_time_recent_interrupted",
+               "cyclic_time_first_interrupted",
+               "sending_balance_time_recent_interrupted",
+               "sending_balance_time_first_interrupted",
+               "receiving_balance_time_recent_interrupted",
+               "receiving_balance_time_first_interrupted")) {
+    expect_error(
+      simulate_relational_events(
+        n_events = 5,
+        senders = c("a", "b"), receivers = c("x", "y", "z"),
+        endogenous_stats = st,
+        endogenous_effects = 0.5),
+      "one-mode",
+      info = st)
+  }
+})
+
+test_that("interrupted triadic timing runs under tau-leap", {
+  set.seed(95)
+  stats_vec <- c("transitivity_time_recent_interrupted",
+                  "transitivity_time_first_interrupted",
+                  "cyclic_time_recent_interrupted",
+                  "cyclic_time_first_interrupted",
+                  "sending_balance_time_recent_interrupted",
+                  "sending_balance_time_first_interrupted",
+                  "receiving_balance_time_recent_interrupted",
+                  "receiving_balance_time_first_interrupted")
+  ev <- simulate_relational_events(
+    n_events = 30,
+    senders = LETTERS[1:5], receivers = LETTERS[1:5],
+    baseline_rate = 2,
+    endogenous_stats = stats_vec,
+    endogenous_effects = setNames(rep(0, length(stats_vec)), stats_vec),
+    method = "tau_leap", tau = 0.02)
+  for (st in stats_vec) expect_true(all(ev[[st]] >= 0), info = st)
+})


### PR DESCRIPTION
## Summary

Wires eight new interrupted timing statistics into the simulator — the most empirically supported variants of the triadic closure family per Juozaitienė & Wit (2024) §2.2.2 and Table 3:

| family | stat names | paper |
|---|---|---|
| transitivity | \`*_time_recent_interrupted\`, \`*_time_first_interrupted\` | t^(7ai), t^(7bi) |
| cyclic       | \`*_time_recent_interrupted\`, \`*_time_first_interrupted\` | c^(7ai), c^(7bi) |
| sending_balance | \`*_time_recent_interrupted\`, \`*_time_first_interrupted\` | sb^(7ai), sb^(7bi) |
| receiving_balance | \`*_time_recent_interrupted\`, \`*_time_first_interrupted\` | rb^(7ai), rb^(7bi) |

Paper Table 3 selects t^(7ai) in 3/4 of the datasets with triadic effects; c^(7ai), sb^(7ai), rb^(7ai) on the larger Social Evolution and Manufacturing datasets.

## Implementation

\`two_path_time_lookup\` now carries an \`interrupted\` flag alongside \`family\` and \`first\`. The lookup-driven update branch unconditionally resets the firing dyad's own cell to \`NA\` after the gated \`apply_time_writes()\` sweep when the active stat is interrupted (every (s, r) event closes any open triad rooted at that dyad). Both inner loops share the dispatch; the τ-leap snapshot list now includes the new state matrices.

## Test plan

- [x] \`tests/testthat/test-interrupted-triadic-timing.R\` (8 blocks, 245 assertions) — exact equality vs. a brute-force closure-aware enumerator for all four families; first ≥ recent invariant; interrupted ≤ continuous on every row; post-closure zero sweep; bipartite raises; tau-leap stays non-negative.
- [x] Full suite: 2232 PASS / 0 FAIL.
- [x] \`devtools::check()\` — 0 errors, 0 warnings, 4 notes (all pre-existing).

## Follow-up

The post-hoc \`compute_endogenous_features()\` engine does **not** yet support these eight stats. A future PR will mirror them there and extend the sim ↔ post-hoc parity suite. The simulator-side coverage is the highest-impact part of the gap given that these are the variants Table 3 selects.