### PR TITLE
Post-hoc interrupted count/binary/exp_decay for triadic families

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -312,12 +312,16 @@ compute_endogenous_features <- function(
     "transitivity_time_recent_ordered", "transitivity_time_first_ordered",
     "transitivity_time_recent_interrupted",
     "transitivity_time_first_interrupted",
+    "transitivity_count_interrupted", "transitivity_binary_interrupted",
+    "transitivity_exp_decay_interrupted",
     "cyclic_binary", "cyclic_count", "cyclic_time_recent", "cyclic_time_first",
     "cyclic_exp_decay",
     "cyclic_binary_ordered", "cyclic_count_ordered",
     "cyclic_exp_decay_ordered",
     "cyclic_time_recent_ordered", "cyclic_time_first_ordered",
     "cyclic_time_recent_interrupted", "cyclic_time_first_interrupted",
+    "cyclic_count_interrupted", "cyclic_binary_interrupted",
+    "cyclic_exp_decay_interrupted",
     "sending_balance_binary", "sending_balance_count",
     "sending_balance_time_recent", "sending_balance_time_first",
     "sending_balance_exp_decay",
@@ -327,6 +331,9 @@ compute_endogenous_features <- function(
     "sending_balance_time_first_ordered",
     "sending_balance_time_recent_interrupted",
     "sending_balance_time_first_interrupted",
+    "sending_balance_count_interrupted",
+    "sending_balance_binary_interrupted",
+    "sending_balance_exp_decay_interrupted",
     "receiving_balance_binary", "receiving_balance_count",
     "receiving_balance_time_recent", "receiving_balance_time_first",
     "receiving_balance_exp_decay",
@@ -335,7 +342,10 @@ compute_endogenous_features <- function(
     "receiving_balance_time_recent_ordered",
     "receiving_balance_time_first_ordered",
     "receiving_balance_time_recent_interrupted",
-    "receiving_balance_time_first_interrupted"
+    "receiving_balance_time_first_interrupted",
+    "receiving_balance_count_interrupted",
+    "receiving_balance_binary_interrupted",
+    "receiving_balance_exp_decay_interrupted"
   )
   bad <- setdiff(stats, allowed)
   if (length(bad)) {
@@ -348,11 +358,15 @@ compute_endogenous_features <- function(
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
                        "transitivity_exp_decay_ordered",
                        "reciprocity_exp_decay_interrupted",
+                       "transitivity_exp_decay_interrupted",
                        "cyclic_exp_decay", "cyclic_exp_decay_ordered",
+                       "cyclic_exp_decay_interrupted",
                        "sending_balance_exp_decay",
                        "sending_balance_exp_decay_ordered",
+                       "sending_balance_exp_decay_interrupted",
                        "receiving_balance_exp_decay",
-                       "receiving_balance_exp_decay_ordered")
+                       "receiving_balance_exp_decay_ordered",
+                       "receiving_balance_exp_decay_interrupted")
   if (any(exp_decay_stats %in% stats) &&
       (is.null(half_life) || !is.numeric(half_life) || half_life <= 0)) {
     stop("`half_life` must be a positive number when ",
@@ -397,14 +411,20 @@ compute_endogenous_features <- function(
                    "transitivity_time_recent_ordered",
                    "transitivity_time_first_ordered",
                    "transitivity_time_recent_interrupted",
-                   "transitivity_time_first_interrupted")
+                   "transitivity_time_first_interrupted",
+                   "transitivity_count_interrupted",
+                   "transitivity_binary_interrupted",
+                   "transitivity_exp_decay_interrupted")
   cyc_names   <- c("cyclic_binary", "cyclic_count",
                    "cyclic_binary_ordered", "cyclic_count_ordered",
                    "cyclic_time_recent", "cyclic_time_first",
                    "cyclic_time_recent_ordered", "cyclic_time_first_ordered",
                    "cyclic_exp_decay", "cyclic_exp_decay_ordered",
                    "cyclic_time_recent_interrupted",
-                   "cyclic_time_first_interrupted")
+                   "cyclic_time_first_interrupted",
+                   "cyclic_count_interrupted",
+                   "cyclic_binary_interrupted",
+                   "cyclic_exp_decay_interrupted")
   sb_names    <- c("sending_balance_binary", "sending_balance_count",
                    "sending_balance_binary_ordered",
                    "sending_balance_count_ordered",
@@ -414,7 +434,10 @@ compute_endogenous_features <- function(
                    "sending_balance_exp_decay",
                    "sending_balance_exp_decay_ordered",
                    "sending_balance_time_recent_interrupted",
-                   "sending_balance_time_first_interrupted")
+                   "sending_balance_time_first_interrupted",
+                   "sending_balance_count_interrupted",
+                   "sending_balance_binary_interrupted",
+                   "sending_balance_exp_decay_interrupted")
   rb_names    <- c("receiving_balance_binary", "receiving_balance_count",
                    "receiving_balance_binary_ordered",
                    "receiving_balance_count_ordered",
@@ -424,7 +447,10 @@ compute_endogenous_features <- function(
                    "receiving_balance_exp_decay",
                    "receiving_balance_exp_decay_ordered",
                    "receiving_balance_time_recent_interrupted",
-                   "receiving_balance_time_first_interrupted")
+                   "receiving_balance_time_first_interrupted",
+                   "receiving_balance_count_interrupted",
+                   "receiving_balance_binary_interrupted",
+                   "receiving_balance_exp_decay_interrupted")
   need_triadic <- any(c(trans_names, cyc_names, sb_names, rb_names) %in% stats)
 
   # --- Tracking data structures ---
@@ -470,23 +496,35 @@ compute_endogenous_features <- function(
   binary_set <- c("reciprocity", "reciprocity_binary",
                   "reciprocity_binary_interrupted",
                   "transitivity_binary", "transitivity_binary_ordered",
+                  "transitivity_binary_interrupted",
                   "cyclic_binary", "cyclic_binary_ordered",
+                  "cyclic_binary_interrupted",
                   "sending_balance_binary",
                   "sending_balance_binary_ordered",
+                  "sending_balance_binary_interrupted",
                   "receiving_balance_binary",
+                  "receiving_balance_binary_interrupted",
                   "receiving_balance_binary_ordered")
   count_set <- c("sender_outdegree", "receiver_indegree",
                  "reciprocity_count", "reciprocity_exp_decay",
                  "transitivity_count", "transitivity_count_ordered",
                  "transitivity_exp_decay", "transitivity_exp_decay_ordered",
+                 "transitivity_count_interrupted",
+                 "transitivity_exp_decay_interrupted",
                  "cyclic_count", "cyclic_count_ordered",
                  "cyclic_exp_decay", "cyclic_exp_decay_ordered",
+                 "cyclic_count_interrupted",
+                 "cyclic_exp_decay_interrupted",
                  "sending_balance_count", "sending_balance_count_ordered",
                  "sending_balance_exp_decay",
                  "sending_balance_exp_decay_ordered",
+                 "sending_balance_count_interrupted",
+                 "sending_balance_exp_decay_interrupted",
                  "receiving_balance_count", "receiving_balance_count_ordered",
                  "receiving_balance_exp_decay",
                  "receiving_balance_exp_decay_ordered",
+                 "receiving_balance_count_interrupted",
+                 "receiving_balance_exp_decay_interrupted",
                  "reciprocity_count_interrupted",
                  "reciprocity_exp_decay_interrupted")
   for (stat in stats) {
@@ -527,18 +565,23 @@ compute_endogenous_features <- function(
       return(res)
     }
 
-    need_ord  <- any(grepl("ordered", req))
-    need_exp  <- any(grepl("exp_decay", req))
-    need_time <- any(grepl("time_", req))
-    need_int  <- any(grepl("_time_[a-z]+_interrupted$", req))
+    need_ord       <- any(grepl("ordered", req))
+    need_exp       <- any(grepl("exp_decay", req))
+    need_time      <- any(grepl("time_", req))
+    need_int_time  <- any(grepl("_time_[a-z]+_interrupted$", req))
+    need_int_count <- any(grepl("_(count|binary)_interrupted$", req))
+    need_int_exp   <- any(grepl("_exp_decay_interrupted$", req))
+    need_int       <- need_int_time || need_int_count || need_int_exp
 
     form_recent     <- -Inf
     form_first      <- Inf
     n_ordered       <- 0L
+    n_int           <- 0L
     form_ord_recent <- -Inf
     form_ord_first  <- Inf
     exp_sum         <- 0
     exp_ord_sum     <- 0
+    exp_int_sum     <- 0
     # Interrupted-window aggregates: only per-k formation times that
     # occurred strictly after the most recent (s, r) closure.
     form_int_recent <- -Inf
@@ -561,8 +604,13 @@ compute_endogenous_features <- function(
         if (formation < form_first)  form_first  <- formation
       }
       if (need_int && formation > t_closure) {
+        n_int <- n_int + 1L
         if (formation > form_int_recent) form_int_recent <- formation
         if (formation < form_int_first)  form_int_first  <- formation
+        if (need_int_exp && !is.null(half_life)) {
+          exp_int_sum <- exp_int_sum +
+            exp(-(t_now - formation) * log(2) / half_life)
+        }
       }
       if (need_exp && !is.null(half_life)) {
         exp_sum <- exp_sum +
@@ -611,9 +659,10 @@ compute_endogenous_features <- function(
       if (eo_nm  %in% req) res[[eo_nm]]  <- 0
     }
 
-    # Interrupted timing outputs (no count / binary / exp_decay variants
-    # in this batch -- only the *_time_recent_interrupted / _time_first_
-    # interrupted slots are populated).
+    # Interrupted-window outputs: every formation strictly after the most
+    # recent (s, r) closure event contributes a fresh "k that closed
+    # since the last (s, r)". `n_int` counts such k's; the timing /
+    # exp-decay aggregates above hold the per-window summaries.
     tri_nm <- paste0(prefix, "_time_recent_interrupted")
     tfi_nm <- paste0(prefix, "_time_first_interrupted")
     if (tri_nm %in% req) {
@@ -622,6 +671,12 @@ compute_endogenous_features <- function(
     if (tfi_nm %in% req) {
       res[[tfi_nm]] <- if (form_int_first  <  Inf) t_now - form_int_first  else NA_real_
     }
+    ci_nm  <- paste0(prefix, "_count_interrupted")
+    bi_nm  <- paste0(prefix, "_binary_interrupted")
+    ei_nm  <- paste0(prefix, "_exp_decay_interrupted")
+    if (ci_nm %in% req) res[[ci_nm]] <- n_int
+    if (bi_nm %in% req) res[[bi_nm]] <- as.integer(n_int > 0L)
+    if (ei_nm %in% req) res[[ei_nm]] <- exp_int_sum
 
     res
   }

--- a/tests/testthat/test-interrupted-triadic.R
+++ b/tests/testthat/test-interrupted-triadic.R
@@ -1,0 +1,146 @@
+# test-interrupted-triadic.R
+# Post-hoc engine support for the count / binary / exp_decay variants
+# of the *_interrupted family across transitivity, cyclic, sending-
+# balance, and receiving-balance. Pins the new stats against a
+# brute-force reference on a fixed event log.
+#
+# Semantics (matches compute_triadic in R/preprocess.R):
+#   `interrupted` counts intermediaries k whose chain (per the family's
+#   leg pairing) formed strictly after the last (s, r) closure event.
+#   Each k contributes once per closure window.
+
+# Brute-force per-row computation. Given the event prefix `prior`, the
+# focal (s, r) pair, candidate intermediaries, and per-family leg
+# directions, return the vector of per-k formation times that fall in
+# the current interrupted window.
+interrupted_window_formations <- function(prior, s, r, actors,
+                                          leg1_dir, leg2_dir) {
+  # Most recent (s, r) closure before this event.
+  sr_times <- prior$time[prior$sender == s & prior$receiver == r]
+  t_closure <- if (length(sr_times)) max(sr_times) else -Inf
+  out <- numeric(0)
+  for (k in actors) {
+    if (k == s || k == r) next
+    e1 <- leg1_dir(k, s, r)
+    e2 <- leg2_dir(k, s, r)
+    t1 <- prior$time[prior$sender == e1[1] & prior$receiver == e1[2]]
+    t2 <- prior$time[prior$sender == e2[1] & prior$receiver == e2[2]]
+    if (!length(t1) || !length(t2)) next
+    # Per-compute_triadic convention: per-k formation time is the
+    # later of the two legs' earliest occurrences.
+    formation <- max(min(t1), min(t2))
+    if (formation > t_closure) out <- c(out, formation)
+  }
+  out
+}
+
+fam_dirs <- list(
+  transitivity = list(
+    leg1 = function(k, s, r) c(s, k),  # s -> k
+    leg2 = function(k, s, r) c(k, r)), # k -> r
+  cyclic = list(
+    leg1 = function(k, s, r) c(r, k),
+    leg2 = function(k, s, r) c(k, s)),
+  sending_balance = list(
+    leg1 = function(k, s, r) c(s, k),
+    leg2 = function(k, s, r) c(r, k)),
+  receiving_balance = list(
+    leg1 = function(k, s, r) c(k, s),
+    leg2 = function(k, s, r) c(k, r))
+)
+
+ev_fixture <- data.frame(
+  sender   = c("A","B","C","A","B","C","A","D","B","C","A","D","C","B","A","D"),
+  receiver = c("B","C","A","C","A","B","D","B","D","D","B","A","B","A","C","C"),
+  time     = seq_len(16) * 1.25,
+  stringsAsFactors = FALSE)
+actors <- sort(unique(c(ev_fixture$sender, ev_fixture$receiver)))
+half_life <- 4
+
+run_family_check <- function(family) {
+  stats <- c(paste0(family, "_count_interrupted"),
+             paste0(family, "_binary_interrupted"),
+             paste0(family, "_exp_decay_interrupted"))
+  out <- compute_endogenous_features(ev_fixture, stats = stats,
+                                      half_life = half_life)
+  dirs <- fam_dirs[[family]]
+  for (i in seq_len(nrow(ev_fixture))) {
+    prior <- ev_fixture[seq_len(i - 1L), , drop = FALSE]
+    forms <- interrupted_window_formations(prior,
+              ev_fixture$sender[i], ev_fixture$receiver[i],
+              actors, dirs$leg1, dirs$leg2)
+    exp_count  <- length(forms)
+    exp_binary <- as.integer(exp_count > 0L)
+    t_now <- ev_fixture$time[i]
+    exp_decay  <- if (exp_count) {
+      sum(exp(-(t_now - forms) * log(2) / half_life))
+    } else 0
+    expect_equal(out[[stats[1]]][i], as.numeric(exp_count),
+                 info = paste(family, "row", i, "count"))
+    expect_equal(out[[stats[2]]][i], exp_binary,
+                 info = paste(family, "row", i, "binary"))
+    expect_equal(out[[stats[3]]][i], exp_decay, tolerance = 1e-9,
+                 info = paste(family, "row", i, "exp_decay"))
+  }
+}
+
+test_that("transitivity_*_interrupted (count/binary/exp_decay) match brute force", {
+  run_family_check("transitivity")
+})
+
+test_that("cyclic_*_interrupted match brute force", {
+  run_family_check("cyclic")
+})
+
+test_that("sending_balance_*_interrupted match brute force", {
+  run_family_check("sending_balance")
+})
+
+test_that("receiving_balance_*_interrupted match brute force", {
+  run_family_check("receiving_balance")
+})
+
+test_that("binary_interrupted equals (count_interrupted > 0) for every family", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    out <- compute_endogenous_features(ev_fixture,
+      stats = c(paste0(family, "_count_interrupted"),
+                paste0(family, "_binary_interrupted")))
+    expect_equal(out[[paste0(family, "_binary_interrupted")]],
+                 as.integer(out[[paste0(family, "_count_interrupted")]] > 0),
+                 info = family)
+  }
+})
+
+test_that("count_interrupted is <= unordered count on every row", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    out <- compute_endogenous_features(ev_fixture,
+      stats = c(paste0(family, "_count"),
+                paste0(family, "_count_interrupted")))
+    expect_true(all(out[[paste0(family, "_count_interrupted")]] <=
+                    out[[paste0(family, "_count")]]),
+                info = family)
+  }
+})
+
+test_that("exp_decay_interrupted requires half_life", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    expect_error(
+      compute_endogenous_features(ev_fixture,
+        stats = paste0(family, "_exp_decay_interrupted")),
+      regexp = "half_life")
+  }
+})
+
+test_that("exp_decay_interrupted is finite and non-negative", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    col <- paste0(family, "_exp_decay_interrupted")
+    out <- compute_endogenous_features(ev_fixture,
+      stats = col, half_life = 4)
+    v <- out[[col]]
+    expect_true(all(is.finite(v)) && all(v >= 0), info = family)
+  }
+})


### PR DESCRIPTION
## Summary

- Closes the last remaining catalogue gap on the post-hoc engine: adds `count_interrupted`, `binary_interrupted`, `exp_decay_interrupted` variants for `transitivity`, `cyclic`, `sending_balance`, `receiving_balance` (12 new stats; reciprocity already had them). Catalogue now stands at **68 statistics**.
- Semantics (matches the `compute_triadic` helper convention): an interrupted chain counts an intermediary `k` whose two-path (per the family's leg pairing) formed strictly **after** the most recent `(s, r)` closure event. `count_interrupted` = number of such k; `binary_interrupted` = indicator; `exp_decay_interrupted` = half-life-weighted sum.
- Simulator-side support for these 12 variants is a follow-up; existing tests for the already-shipped `*_time_*_interrupted` variants continue to pass unchanged.

## Test plan
- [x] New `tests/testthat/test-interrupted-triadic.R`: brute-force reference, 4 family checks + 3 invariant checks (binary↔count, ordering vs unordered count, half_life required for exp_decay, finiteness/non-negativity).
- [x] `devtools::test()` full suite — green; only the 3 known frailty-convergence warnings from #45.
- [x] `compute_endogenous_features()` smoke test on a 10-row event log returns sane values across all four families.