### PR TITLE
Simulator-side interrupted count/binary/exp_decay for triadic families

### DIFF
--- a/R/simulate_events.R
+++ b/R/simulate_events.R
@@ -417,12 +417,24 @@ simulate_relational_events <- function(
                      "receiving_balance_exp_decay_ordered",
                      "transitivity_time_recent_interrupted",
                      "transitivity_time_first_interrupted",
+                     "transitivity_count_interrupted",
+                     "transitivity_binary_interrupted",
+                     "transitivity_exp_decay_interrupted",
                      "cyclic_time_recent_interrupted",
                      "cyclic_time_first_interrupted",
+                     "cyclic_count_interrupted",
+                     "cyclic_binary_interrupted",
+                     "cyclic_exp_decay_interrupted",
                      "sending_balance_time_recent_interrupted",
                      "sending_balance_time_first_interrupted",
+                     "sending_balance_count_interrupted",
+                     "sending_balance_binary_interrupted",
+                     "sending_balance_exp_decay_interrupted",
                      "receiving_balance_time_recent_interrupted",
-                     "receiving_balance_time_first_interrupted")
+                     "receiving_balance_time_first_interrupted",
+                     "receiving_balance_count_interrupted",
+                     "receiving_balance_binary_interrupted",
+                     "receiving_balance_exp_decay_interrupted")
   ordered_stats <- c("transitivity_count_ordered",
                      "transitivity_binary_ordered",
                      "transitivity_time_recent_ordered",
@@ -466,11 +478,15 @@ simulate_relational_events <- function(
   exp_decay_stats <- c("reciprocity_exp_decay", "transitivity_exp_decay",
                        "transitivity_exp_decay_ordered",
                        "reciprocity_exp_decay_interrupted",
+                       "transitivity_exp_decay_interrupted",
                        "cyclic_exp_decay",
                        "cyclic_exp_decay_ordered",
+                       "cyclic_exp_decay_interrupted",
                        "sending_balance_exp_decay",
                        "sending_balance_exp_decay_ordered",
+                       "sending_balance_exp_decay_interrupted",
                        "receiving_balance_exp_decay",
+                       "receiving_balance_exp_decay_interrupted",
                        "receiving_balance_exp_decay_ordered")
   degree_stats <- c("sender_outdegree", "receiver_indegree")
   supported_endogenous <- c(reciprocity_stats, "recency",
@@ -765,6 +781,29 @@ simulate_relational_events <- function(
     receiving_balance_time_first  = list(family = "receiving_balance", first = TRUE)
   )
 
+  # Count / binary / exp_decay variants of the *_interrupted family for
+  # each closure family. Same chain-creation semantics as the time-
+  # interrupted variants: when a fired event (i, j) closes a new
+  # two-path for some intermediary k, bump the focal-pair count cell;
+  # when (i, j) itself fires it resets its own focal cell to 0 because
+  # the (s, r) closure starts a fresh interrupted window. Mirrors
+  # compute_triadic's n_int / exp_int_sum accumulators on the post-hoc
+  # side (R/preprocess.R).
+  two_path_interrupted_count_lookup <- list(
+    transitivity_count_interrupted        = list(family = "transitivity",      kind = "count"),
+    transitivity_binary_interrupted       = list(family = "transitivity",      kind = "binary"),
+    transitivity_exp_decay_interrupted    = list(family = "transitivity",      kind = "exp_decay"),
+    cyclic_count_interrupted              = list(family = "cyclic",            kind = "count"),
+    cyclic_binary_interrupted             = list(family = "cyclic",            kind = "binary"),
+    cyclic_exp_decay_interrupted          = list(family = "cyclic",            kind = "exp_decay"),
+    sending_balance_count_interrupted     = list(family = "sending_balance",   kind = "count"),
+    sending_balance_binary_interrupted    = list(family = "sending_balance",   kind = "binary"),
+    sending_balance_exp_decay_interrupted = list(family = "sending_balance",   kind = "exp_decay"),
+    receiving_balance_count_interrupted     = list(family = "receiving_balance", kind = "count"),
+    receiving_balance_binary_interrupted    = list(family = "receiving_balance", kind = "binary"),
+    receiving_balance_exp_decay_interrupted = list(family = "receiving_balance", kind = "exp_decay")
+  )
+
   # Returns the (row, col) integer matrix of state-matrix cells that are
   # newly "two-path-formed" by event (i, j), given `adj` = current binary
   # adjacency *before* (i, j) is added. The four families correspond to the
@@ -1011,6 +1050,18 @@ simulate_relational_events <- function(
         "sending_balance_time_first_interrupted"   = time_elapsed_or_zero(endo_state[[st]]),
         "receiving_balance_time_recent_interrupted"= time_elapsed_or_zero(endo_state[[st]]),
         "receiving_balance_time_first_interrupted" = time_elapsed_or_zero(endo_state[[st]]),
+        "transitivity_count_interrupted"      = endo_state[[st]] * 1.0,
+        "transitivity_binary_interrupted"     = (endo_state[[st]] > 0) * 1.0,
+        "transitivity_exp_decay_interrupted"  = endo_state[[st]],
+        "cyclic_count_interrupted"            = endo_state[[st]] * 1.0,
+        "cyclic_binary_interrupted"           = (endo_state[[st]] > 0) * 1.0,
+        "cyclic_exp_decay_interrupted"        = endo_state[[st]],
+        "sending_balance_count_interrupted"   = endo_state[[st]] * 1.0,
+        "sending_balance_binary_interrupted"  = (endo_state[[st]] > 0) * 1.0,
+        "sending_balance_exp_decay_interrupted" = endo_state[[st]],
+        "receiving_balance_count_interrupted"   = endo_state[[st]] * 1.0,
+        "receiving_balance_binary_interrupted"  = (endo_state[[st]] > 0) * 1.0,
+        "receiving_balance_exp_decay_interrupted" = endo_state[[st]],
         "sender_outdegree"          = matrix(sender_out_count, nrow = S, ncol = R),
         "receiver_indegree"         = matrix(receiver_in_count, nrow = S, ncol = R,
                                               byrow = TRUE),
@@ -1331,6 +1382,20 @@ simulate_relational_events <- function(
                       endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
                     }
                   }
+                } else if (!is.null(two_path_interrupted_count_lookup[[st]])) {
+                  info <- two_path_interrupted_count_lookup[[st]]
+                  if (adj_state[u_s, u_r] == 0) {
+                    writes <- two_path_writes(info$family, u_s, u_r, adj_state)
+                    if (nrow(writes)) {
+                      if (info$kind == "binary") {
+                        endo_state[[st]][writes] <- 1L
+                      } else {
+                        endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
+                      }
+                    }
+                  }
+                  reset_val <- if (info$kind == "binary") 0L else 0
+                  endo_state[[st]][u_s, u_r] <- reset_val
                 }
               }
               if (has_network_stats) {
@@ -1540,6 +1605,20 @@ simulate_relational_events <- function(
               endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
             }
           }
+        } else if (!is.null(two_path_interrupted_count_lookup[[st]])) {
+          info <- two_path_interrupted_count_lookup[[st]]
+          if (adj_state[u_s, u_r] == 0) {
+            writes <- two_path_writes(info$family, u_s, u_r, adj_state)
+            if (nrow(writes)) {
+              if (info$kind == "binary") {
+                endo_state[[st]][writes] <- 1L
+              } else {
+                endo_state[[st]][writes] <- endo_state[[st]][writes] + 1
+              }
+            }
+          }
+          reset_val <- if (info$kind == "binary") 0L else 0
+          endo_state[[st]][u_s, u_r] <- reset_val
         }
       }
       if (has_network_stats) {

--- a/tests/testthat/test-interrupted-triadic-simulator.R
+++ b/tests/testthat/test-interrupted-triadic-simulator.R
@@ -1,0 +1,131 @@
+# test-interrupted-triadic-simulator.R
+# Simulator-side generation of the count / binary / exp_decay variants
+# of the *_interrupted family for the four closure families. Each test
+# simulates an event log with one family's interrupted stats active
+# and verifies the per-row simulator output matches what the post-hoc
+# engine (already covered by test-interrupted-triadic.R) produces from
+# the same event log.
+
+run_parity <- function(family, seed, n_events = 40, n_actors = 5,
+                       baseline_rate = 2, half_life = 4) {
+  stats <- c(paste0(family, "_count_interrupted"),
+             paste0(family, "_binary_interrupted"),
+             paste0(family, "_exp_decay_interrupted"))
+  set.seed(seed)
+  ev <- simulate_relational_events(
+    n_events = n_events,
+    senders = LETTERS[1:n_actors], receivers = LETTERS[1:n_actors],
+    baseline_rate = baseline_rate,
+    endogenous_stats = stats,
+    endogenous_effects = setNames(rep(0, length(stats)), stats),
+    half_life = half_life)
+  ref <- compute_endogenous_features(
+    ev[, c("sender", "receiver", "time")],
+    stats = stats, half_life = half_life)
+  for (st in stats) {
+    expect_equal(ev[[st]], ref[[st]], tolerance = 1e-9,
+                 info = paste(family, st))
+  }
+}
+
+test_that("transitivity_*_interrupted (count/binary/exp_decay) match the post-hoc engine", {
+  for (sd in c(11, 12, 13)) run_parity("transitivity", sd)
+})
+
+test_that("cyclic_*_interrupted match the post-hoc engine", {
+  for (sd in c(21, 22, 23)) run_parity("cyclic", sd)
+})
+
+test_that("sending_balance_*_interrupted match the post-hoc engine", {
+  for (sd in c(31, 32, 33)) run_parity("sending_balance", sd)
+})
+
+test_that("receiving_balance_*_interrupted match the post-hoc engine", {
+  for (sd in c(41, 42, 43)) run_parity("receiving_balance", sd)
+})
+
+test_that("count_interrupted is <= unordered count on every simulated row", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    stat_int <- paste0(family, "_count_interrupted")
+    stat_unord <- paste0(family, "_count")
+    set.seed(101)
+    ev <- simulate_relational_events(
+      n_events = 35,
+      senders = LETTERS[1:5], receivers = LETTERS[1:5],
+      baseline_rate = 2,
+      endogenous_stats = c(stat_unord, stat_int),
+      endogenous_effects = setNames(c(0, 0), c(stat_unord, stat_int)))
+    expect_true(all(ev[[stat_int]] <= ev[[stat_unord]]), info = family)
+  }
+})
+
+test_that("binary_interrupted equals (count_interrupted > 0) for each family", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    count_st  <- paste0(family, "_count_interrupted")
+    binary_st <- paste0(family, "_binary_interrupted")
+    set.seed(202)
+    ev <- simulate_relational_events(
+      n_events = 25,
+      senders = LETTERS[1:5], receivers = LETTERS[1:5],
+      baseline_rate = 2,
+      endogenous_stats = c(count_st, binary_st),
+      endogenous_effects = setNames(c(0, 0), c(count_st, binary_st)))
+    expect_equal(ev[[binary_st]], as.numeric(ev[[count_st]] > 0),
+                 info = family)
+  }
+})
+
+test_that("interrupted stats work under tau-leap", {
+  for (family in c("transitivity", "cyclic",
+                   "sending_balance", "receiving_balance")) {
+    stats <- c(paste0(family, "_count_interrupted"),
+               paste0(family, "_binary_interrupted"))
+    set.seed(505)
+    ev <- simulate_relational_events(
+      n_events = 30,
+      senders = LETTERS[1:5], receivers = LETTERS[1:5],
+      baseline_rate = 2,
+      endogenous_stats = stats,
+      endogenous_effects = setNames(c(0, 0), stats),
+      method = "tau_leap", tau = 0.02)
+    expect_equal(ev[[stats[2]]], as.numeric(ev[[stats[1]]] > 0),
+                 info = family)
+  }
+})
+
+test_that("exp_decay_interrupted requires half_life at the simulator", {
+  expect_error(
+    simulate_relational_events(
+      n_events = 10,
+      senders = LETTERS[1:4], receivers = LETTERS[1:4],
+      baseline_rate = 1,
+      endogenous_stats = "cyclic_exp_decay_interrupted",
+      endogenous_effects = c(cyclic_exp_decay_interrupted = 0)),
+    regexp = "half_life")
+})
+
+test_that("a positive coefficient on transitivity_count_interrupted is sign-recoverable", {
+  skip_on_cran()
+  skip_if_not_installed("mgcv")
+  set.seed(2026)
+  true_beta <- 0.35
+  cc <- simulate_relational_events(
+    n_events = 1500,
+    senders = LETTERS[1:8], receivers = LETTERS[1:8],
+    baseline_rate = 1, allow_loops = FALSE,
+    n_controls = 1,
+    endogenous_stats = "transitivity_count_interrupted",
+    endogenous_effects = c(transitivity_count_interrupted = true_beta))
+  cases <- cc[cc$event == 1L, ]; cases <- cases[order(cases$stratum), ]
+  ctrls <- cc[cc$event == 0L, ]; ctrls <- ctrls[order(ctrls$stratum), ]
+  df <- data.frame(
+    one = rep(1, nrow(cases)),
+    delta_t = cases$transitivity_count_interrupted -
+              ctrls$transitivity_count_interrupted)
+  fit <- mgcv::gam(one ~ delta_t - 1, family = "binomial", data = df)
+  est <- unname(stats::coef(fit)[1])
+  expect_true(est > 0.1 && est < 0.7,
+              info = sprintf("estimated effect = %.3f", est))
+})


### PR DESCRIPTION
## Summary

Closes the catalogue at **68 statistics, all parity-tested between the simulator and the post-hoc engine.** Adds generative support for the 12 variants that landed post-hoc in #49: `{transitivity,cyclic,sending_balance,receiving_balance}_{count,binary,exp_decay}_interrupted`.

Implementation mirrors the existing `*_time_*_interrupted` machinery:

- New `two_path_interrupted_count_lookup` maps each new stat to (family, kind ∈ {count, binary, exp_decay}).
- At each fired event `(u_s, u_r)`:
  - If `adj[u_s, u_r] == 0` (first firing closes new two-paths), bump the formed two-path cells for count/exp_decay, or set them to `1` for binary.
  - Always reset `endo_state[stat][u_s, u_r] = 0` — start a fresh interrupted window for the focal pair.
- Reset + chain-creation logic mirrors `compute_triadic`'s `n_int` / `exp_int_sum` accumulators on the post-hoc side.
- `exp_decay_stats` list extended so the existing decay-applied-each-step loop covers the new exp_decay variants.

## Test plan
- [x] New `tests/testthat/test-interrupted-triadic-simulator.R` (50 assertions): row-for-row parity vs the post-hoc engine across 3 seeds × 4 families, plus binary↔count, count↔unordered-count, tau-leap, half_life-required, and sign-recoverability checks.
- [x] `devtools::test()` full suite green; only the 3 known frailty-convergence warnings from #45.
- [x] Smoke test confirmed `simulate_relational_events()` emits a column-for-column match against `compute_endogenous_features()` on a 30-event log.