### PR TITLE
docs: drop stale Limitations-and-roadmap link

### DIFF
--- a/R/simulate_directed_hyperedge_events.R
+++ b/R/simulate_directed_hyperedge_events.R
@@ -24,8 +24,7 @@
 #'
 #' Candidate-space size is exponential in
 #' \eqn{|V^I|}{|V^I|} and \eqn{|V^J|}{|V^J|}, so practical use is
-#' limited to small actor / item universes (see *Computational cost*
-#' in [Limitations and roadmap](https://github.com/franciscorichter/amore/wiki/Limitations-and-roadmap)).
+#' limited to small actor / item universes.
 #'
 #' @param n_events Number of events to simulate.
 #' @param senders Character vector of sender names \eqn{V^I}{V^I}.

--- a/man/simulate_directed_hyperedge_events.Rd
+++ b/man/simulate_directed_hyperedge_events.Rd
@@ -74,8 +74,7 @@ is exponential with rate equal to the total intensity.
 
 Candidate-space size is exponential in
 \eqn{|V^I|}{|V^I|} and \eqn{|V^J|}{|V^J|}, so practical use is
-limited to small actor / item universes (see \emph{Computational cost}
-in \href{https://github.com/franciscorichter/amore/wiki/Limitations-and-roadmap}{Limitations and roadmap}).
+limited to small actor / item universes.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
The wiki page was removed earlier; this PR drops the broken cross-reference from `simulate_directed_hyperedge_events()`'s roxygen. Surrounding sentence retained.