### PR TITLE
fix(rem): make REML opt-in so re() reproduces Intro-to-REM tutorial (#88)

### DIFF
--- a/R/rem.R
+++ b/R/rem.R
@@ -54,6 +54,10 @@
 #'   (required by `clogit`).
 #' @param time Name of the time column, required for `tve` / `tvnle` terms.
 #' @param k Optional integer basis dimension passed to `s()` / `te()`.
+#' @param gam_method Smoothness-selection method for the `degenerate` backend,
+#'   passed to [mgcv::gam()]. Defaults to `NULL`, which uses mgcv's own default
+#'   (`"GCV.Cp"`) and reproduces the Intro-to-REM tutorial parameterization.
+#'   Set to `"REML"` for the REML fit used in some papers.
 #' @param ... Reserved for future use.
 #'
 #' @return An object of class `"rem"`: a list with the fitted model (`$fit`),
@@ -80,7 +84,7 @@
 rem <- function(formula, data,
                 method = c("degenerate", "clogit"),
                 case = "IS_OBSERVED", stratum = NULL, time = NULL,
-                k = NULL, ...) {
+                k = NULL, gam_method = NULL, ...) {
   method <- match.arg(method)
   if (!inherits(formula, "formula")) stop("`formula` must be a formula.")
   if (!is.data.frame(data)) stop("`data` must be a data.frame.")
@@ -218,7 +222,13 @@ rem <- function(formula, data,
   if (need_ttrans) { tt <- get_time_trans(); df[[".T"]] <- cbind(tt, tt) }
 
   fm <- stats::as.formula(paste("one ~ -1 +", paste(rhs, collapse = " + ")))
-  fit <- mgcv::gam(fm, family = stats::binomial(), data = df, method = "REML")
+  # Smoothness-selection method passed to mgcv::gam(). Default NULL lets mgcv
+  # use its own default ("GCV.Cp"), which reproduces the Intro-to-REM tutorial
+  # parameterization (see issue #88). Set gam_method = "REML" to recover the
+  # REML fit used in some papers.
+  gam_args <- list(formula = fm, family = stats::binomial(), data = df)
+  if (!is.null(gam_method)) gam_args$method <- gam_method
+  fit <- do.call(mgcv::gam, gam_args)
 
   structure(
     list(fit = fit, method = method, formula = formula,

--- a/man/rem.Rd
+++ b/man/rem.Rd
@@ -12,6 +12,7 @@ rem(
   stratum = NULL,
   time = NULL,
   k = NULL,
+  gam_method = NULL,
   ...
 )
 }
@@ -31,6 +32,11 @@ degenerate method; long with a case indicator and stratum for \code{clogit}).}
 \item{time}{Name of the time column, required for \code{tve} / \code{tvnle} terms.}
 
 \item{k}{Optional integer basis dimension passed to \code{s()} / \code{te()}.}
+
+\item{gam_method}{Smoothness-selection method for the \code{degenerate} backend,
+passed to \code{\link[mgcv:gam]{mgcv::gam()}}. Defaults to \code{NULL}, which uses mgcv's own default
+(\code{"GCV.Cp"}) and reproduces the Intro-to-REM tutorial parameterization.
+Set to \code{"REML"} for the REML fit used in some papers.}
 
 \item{...}{Reserved for future use.}
 }

--- a/tests/testthat/test-issue81-effects-fits.R
+++ b/tests/testthat/test-issue81-effects-fits.R
@@ -17,6 +17,32 @@ test_that("G4: rem() builds an re() random-effect smooth", {
   expect_true(is.finite(logLik(fit)))
 })
 
+test_that("G4: re() default fit reproduces plain mgcv::gam; REML is opt-in (issue #88)", {
+  skip_if_not_installed("mgcv")
+  set.seed(3)
+  w <- simulate_relational_events(
+    n_events = 300, senders = paste0("a", 1:8), receivers = paste0("a", 1:8),
+    n_controls = 1, endogenous_stats = "reciprocity_count",
+    endogenous_effects = c(reciprocity_count = 0.6), wide = TRUE)
+
+  fit_default <- rem(~ re(sender), data = w, method = "degenerate")
+  fit_reml    <- rem(~ re(sender), data = w, method = "degenerate",
+                     gam_method = "REML")
+
+  # Tutorial reference: plain mgcv::gam with the matched +-1 factor matrix,
+  # mgcv's own default smoothness selection (no method = "REML").
+  n    <- nrow(w)
+  fmat <- factor(c(as.character(w$sender_ev), as.character(w$sender_nv)))
+  dim(fmat) <- c(n, 2L)
+  df   <- list(one = rep(1, n), .I = cbind(rep(1, n), rep(-1, n)),
+               .RE_sender = fmat)
+  ref  <- mgcv::gam(one ~ -1 + s(.RE_sender, by = .I, bs = "re"),
+                    family = stats::binomial(), data = df)
+
+  expect_equal(unname(coef(fit_default)), unname(coef(ref)))
+  expect_false(isTRUE(all.equal(coef(fit_default), coef(fit_reml))))
+})
+
 test_that("G4: re() on a missing column errors clearly; clogit rejects it", {
   skip_if_not_installed("mgcv")
   set.seed(2)


### PR DESCRIPTION
Closes the parameterization discrepancy @martinaboschi identified in #88.

## Problem
`rem(method = "degenerate")` hardcoded `method = "REML"` in its `mgcv::gam()` call. The Intro-to-REM tutorial fits `gam(y ~ s(sp, by = I, bs = "re") - 1)` with mgcv's **default** smoothness selection (GCV.Cp), so `re()` coefficients did not match `re.species`.

## Fix
New `gam_method` argument on `rem()`, default `NULL` → `method` is omitted from the `gam()` call → mgcv default → reproduces the tutorial. `gam_method = "REML"` recovers the prior behaviour used in some papers.

## Verification
Against the real `dat_gam_FR_intro_to_rems.RData`:
```
amore default == tutorial re.species : TRUE
max |default - tutorial|             : 0
REML opt-in still differs            : TRUE
```
Full suite: 3280 PASS / 0 FAIL. Adds a regression test and regenerates `man/rem.Rd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)