### PR TITLE
Fix workshop issues: widen ids (#92), gam long-format guard (#93), prior_log warm-start (#94)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,20 @@ intended for the first CRAN release.
   formula's left-hand side (e.g. `event ~ x`) for the `clogit`/`nn` backends.
 * `widen_case_control()` auto-detects the 0/1 indicator column (`event` or
   `IS_OBSERVED`) when `case` is not given.
+* `widen_case_control()` now carries the sender/receiver identifiers of the
+  case and its matched control into the output (`sender_ev`/`receiver_ev`/
+  `sender_nv`/`receiver_nv`); the new `keep_ids` argument controls this
+  (default `TRUE`). The dyads behind each pair are no longer lost, and `re()`
+  grouping terms can reach the actor levels (#92).
+* `rem(method = "gam")` now detects long-format case-control input (a
+  `event`/`IS_OBSERVED` indicator with control rows) and widens it with
+  `widen_case_control()` before fitting, emitting a message — instead of
+  silently misreading raw per-row values as event-minus-control differences
+  (#93).
+* `compute_endogenous_features()` gains a `prior_log` argument for
+  warm-starting the network state from events that precede the study window:
+  its rows update the running state but never appear in the output, separating
+  warm-starting from the non-event masking role of `history_log` (#94).
 * `cpp_supported_stats()` is now exported.
 
 # amore 0.1.0

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -242,6 +242,14 @@ attach_static_covariates <- function(
 #'   the history. Defaults to `NULL` (every row is treated as an event).
 #'   Currently supported only for statistics handled by the C++ engine
 #'   (see [cpp_supported_stats()]).
+#' @param prior_log Optional data.frame of events that precede the study window
+#'   (columns `sender`, `receiver`, `time`), used to **warm-start** the network
+#'   state. Its rows always update the running state but never appear in the
+#'   returned data.frame. This separates warm-starting from the non-event
+#'   masking role of `history_log`: pass earlier history through `prior_log`
+#'   and use `history_log` purely to mark which rows of `event_log` are real
+#'   events. Defaults to `NULL`. Like `history_log`, it is currently supported
+#'   only for statistics handled by the C++ engine (see [cpp_supported_stats()]).
 #'
 #' @details All statistics are evaluated immediately **before** the event is
 #'   logged.  They are grouped into five families.
@@ -344,7 +352,8 @@ compute_endogenous_features <- function(
     stats = c("sender_outdegree", "receiver_indegree", "reciprocity", "recency"),
     half_life = NULL,
     sort = TRUE,
-    history_log = NULL) {
+    history_log = NULL,
+    prior_log = NULL) {
 
   if (!is.data.frame(event_log)) {
     stop("`event_log` must be a data.frame.")
@@ -354,6 +363,58 @@ compute_endogenous_features <- function(
   if (length(missing_cols)) {
     stop("Event log is missing required column(s): ",
          paste(missing_cols, collapse = ", "))
+  }
+
+  # Warm-start support (issue #94). `prior_log` holds events that precede the
+  # study window: they must update the running network state but never appear
+  # in the output. We internalize the documented prepend-and-trim recipe ---
+  # prepend the prior events, treat them (and the usual events) as history, run
+  # the normal machinery, then strip the prior rows. This keeps `history_log`
+  # free to do non-event masking on `event_log` alone. Restoring the original
+  # event_log rows by a private row id (not by sender/receiver/time key) makes
+  # the strip robust even if a prior event shares a triple with a real row.
+  if (!is.null(prior_log)) {
+    if (!is.data.frame(prior_log)) {
+      stop("`prior_log` must be a data.frame or NULL.")
+    }
+    pl_missing <- setdiff(required_cols, names(prior_log))
+    if (length(pl_missing)) {
+      stop("`prior_log` is missing required column(s): ",
+           paste(pl_missing, collapse = ", "))
+    }
+    eid <- ".__amore_eid__"
+    event_aug <- event_log
+    event_aug[[eid]] <- seq_len(nrow(event_log))
+    # Prior rows aligned to event_log's columns (extra columns left NA via
+    # NA-row indexing, which preserves each column's type); they carry no event
+    # id so they are dropped after the computation.
+    prior_aug <- event_aug[rep(NA_integer_, nrow(prior_log)), , drop = FALSE]
+    prior_aug$sender   <- as.character(prior_log$sender)
+    prior_aug$receiver <- as.character(prior_log$receiver)
+    prior_aug$time     <- as.numeric(prior_log$time)
+    prior_aug[[eid]]   <- NA_integer_
+    combined <- rbind(prior_aug, event_aug)
+    # Effective history: prior rows always update state; among event_log rows,
+    # those that update state are the ones history_log already designates
+    # (every row, when history_log is NULL).
+    base_hist <- if (is.null(history_log)) event_log else history_log
+    eff_hist <- rbind(
+      data.frame(sender = as.character(prior_log$sender),
+                 receiver = as.character(prior_log$receiver),
+                 time = as.numeric(prior_log$time),
+                 stringsAsFactors = FALSE),
+      data.frame(sender = as.character(base_hist$sender),
+                 receiver = as.character(base_hist$receiver),
+                 time = as.numeric(base_hist$time),
+                 stringsAsFactors = FALSE))
+    res <- compute_endogenous_features(
+      combined, stats = stats, half_life = half_life, sort = sort,
+      history_log = eff_hist, prior_log = NULL)
+    res <- res[!is.na(res[[eid]]), , drop = FALSE]
+    res <- res[order(res[[eid]]), , drop = FALSE]
+    res[[eid]] <- NULL
+    rownames(res) <- NULL
+    return(res)
   }
   # Optional authoritative event history. When supplied, only rows of
   # `event_log` whose (sender, receiver, time) triple appears in

--- a/R/rem.R
+++ b/R/rem.R
@@ -59,7 +59,10 @@
 #'
 #' @param formula A formula; see *Formula syntax*.
 #' @param data A data.frame of preprocessed case-control data (wide for the
-#'   `gam` method; long with a case indicator and stratum for `clogit`).
+#'   `gam` method; long with a case indicator and stratum for `clogit`). For
+#'   `method = "gam"`, long case-control input (a `event`/`IS_OBSERVED`
+#'   indicator with control rows) is detected and widened automatically via
+#'   [widen_case_control()], with a message.
 #' @param method Estimation backend; see *Description*.
 #' @param case Optional name of the 0/1 event-indicator column for the `clogit`
 #'   and `nn` backends. If `NULL` (default), the indicator is taken from the
@@ -196,6 +199,27 @@ rem <- function(formula, data,
     stop("The `mgcv` package is required by rem(method = \"gam\"). ",
          "Install it with install.packages(\"mgcv\").")
   }
+
+  # Guard against long-format data reaching the wide `gam` backend (issue #93).
+  # The gam design is case-1-control: one row per case, each covariate supplied
+  # as an event-minus-control difference. If a 0/1 indicator column
+  # (`event`/`IS_OBSERVED`) with control rows is present, `data` is a long
+  # case-control log; fitting it directly would silently misread the raw
+  # per-row covariate values as differences. Auto-widen (loudly) instead.
+  ind_cand <- intersect(c("event", "IS_OBSERVED"), names(data))
+  if (length(ind_cand)) {
+    ind <- ind_cand[1L]
+    iv <- suppressWarnings(as.integer(data[[ind]]))
+    if (any(!is.na(iv) & iv == 0L)) {
+      message("rem(method = \"gam\"): `data` looks long-format (column '", ind,
+              "' contains control rows); widening it with ",
+              "widen_case_control() before fitting. Pass already-wide data ",
+              "(one row per case) to silence this.")
+      data <- widen_case_control(data, case = ind, stratum = stratum)
+      stratum <- NULL
+    }
+  }
+
   n <- nrow(data)
   if (!n) stop("`data` has no rows.")
 

--- a/R/widen_case_control.R
+++ b/R/widen_case_control.R
@@ -24,8 +24,16 @@
 #'   `INTEGER_TIME`, `TIME_POINT`, `TIME_UNIT`, `EVENT_INTERVAL`).
 #' @param control_index Which control within each stratum to pair with the case
 #'   (default the first). Lets a case-k-control log be reduced to case-1-control.
+#' @param keep_ids Logical; when `TRUE` (default) the sender/receiver identifier
+#'   columns present in `data` are carried into the output as `sender_ev` /
+#'   `receiver_ev` (the observed event) and `sender_nv` / `receiver_nv` (the
+#'   matched control), so the dyads behind each case-control pair remain
+#'   recoverable (and become available to `re()` grouping terms in [rem()]).
+#'   Set to `FALSE` to emit only the widened covariate columns.
 #'
-#' @return A data.frame with one row per case: a `stratum` column and, for each
+#' @return A data.frame with one row per case: a `stratum` column, the
+#'   sender/receiver identifiers (`sender_ev`/`receiver_ev`/`sender_nv`/
+#'   `receiver_nv`, when present in `data` and `keep_ids = TRUE`) and, for each
 #'   covariate, `<cov>_ev`, `<cov>_nv` and `d_<cov>`. Strata without exactly one
 #'   case or without the requested control are dropped (with a message).
 #'
@@ -40,7 +48,8 @@
 #'
 #' @export
 widen_case_control <- function(data, case = NULL, stratum = NULL,
-                               covariates = NULL, control_index = 1L) {
+                               covariates = NULL, control_index = 1L,
+                               keep_ids = TRUE) {
   if (!is.data.frame(data)) stop("`data` must be a data.frame.")
   # Resolve the 0/1 indicator column: explicit `case`, else auto-detect the
   # package (`event`, from sample_non_events()) or eventnet (`IS_OBSERVED`)
@@ -68,6 +77,12 @@ widen_case_control <- function(data, case = NULL, stratum = NULL,
   miss <- setdiff(covariates, names(data))
   if (length(miss)) stop("Covariate column(s) not found: ", paste(miss, collapse = ", "))
 
+  # Identifier columns to carry through (see issue #92). The sender/receiver of
+  # both the case (`_ev`) and the matched control (`_nv`) are otherwise lost in
+  # the wide pivot; keeping them lets callers recover the dyads and lets re()
+  # grouping terms in rem() reach the actor levels.
+  id_cols <- if (isTRUE(keep_ids)) intersect(c("sender", "receiver"), names(data)) else character(0)
+
   idx <- split(seq_len(nrow(data)), strat)
   dropped <- 0L
   rows <- lapply(idx, function(ix) {
@@ -79,6 +94,10 @@ widen_case_control <- function(data, case = NULL, stratum = NULL,
     }
     ctrl <- ct[control_index]
     base <- data.frame(stratum = strat[cs], stringsAsFactors = FALSE)
+    for (idc in id_cols) {
+      base[[paste0(idc, "_ev")]] <- data[[idc]][cs]
+      base[[paste0(idc, "_nv")]] <- data[[idc]][ctrl]
+    }
     for (v in covariates) {
       ev <- as.numeric(data[[v]][cs])
       nv <- as.numeric(data[[v]][ctrl])

--- a/man/compute_endogenous_features.Rd
+++ b/man/compute_endogenous_features.Rd
@@ -9,7 +9,8 @@ compute_endogenous_features(
   stats = c("sender_outdegree", "receiver_indegree", "reciprocity", "recency"),
   half_life = NULL,
   sort = TRUE,
-  history_log = NULL
+  history_log = NULL,
+  prior_log = NULL
 )
 }
 \arguments{
@@ -35,6 +36,15 @@ endogenous statistics for non-events without those non-events polluting
 the history. Defaults to \code{NULL} (every row is treated as an event).
 Currently supported only for statistics handled by the C++ engine
 (see \code{\link[=cpp_supported_stats]{cpp_supported_stats()}}).}
+
+\item{prior_log}{Optional data.frame of events that precede the study window
+(columns \code{sender}, \code{receiver}, \code{time}), used to \strong{warm-start} the network
+state. Its rows always update the running state but never appear in the
+returned data.frame. This separates warm-starting from the non-event
+masking role of \code{history_log}: pass earlier history through \code{prior_log}
+and use \code{history_log} purely to mark which rows of \code{event_log} are real
+events. Defaults to \code{NULL}. Like \code{history_log}, it is currently supported
+only for statistics handled by the C++ engine (see \code{\link[=cpp_supported_stats]{cpp_supported_stats()}}).}
 }
 \value{
 The event log with added columns, one per requested statistic

--- a/man/rem.Rd
+++ b/man/rem.Rd
@@ -21,7 +21,10 @@ rem(
 \item{formula}{A formula; see \emph{Formula syntax}.}
 
 \item{data}{A data.frame of preprocessed case-control data (wide for the
-\code{gam} method; long with a case indicator and stratum for \code{clogit}).}
+\code{gam} method; long with a case indicator and stratum for \code{clogit}). For
+\code{method = "gam"}, long case-control input (a \code{event}/\code{IS_OBSERVED}
+indicator with control rows) is detected and widened automatically via
+\code{\link[=widen_case_control]{widen_case_control()}}, with a message.}
 
 \item{method}{Estimation backend; see \emph{Description}.}
 

--- a/man/widen_case_control.Rd
+++ b/man/widen_case_control.Rd
@@ -9,7 +9,8 @@ widen_case_control(
   case = NULL,
   stratum = NULL,
   covariates = NULL,
-  control_index = 1L
+  control_index = 1L,
+  keep_ids = TRUE
 )
 }
 \arguments{
@@ -31,9 +32,18 @@ stratum, and the standard eventnet bookkeeping columns (\code{EVENT},
 
 \item{control_index}{Which control within each stratum to pair with the case
 (default the first). Lets a case-k-control log be reduced to case-1-control.}
+
+\item{keep_ids}{Logical; when \code{TRUE} (default) the sender/receiver identifier
+columns present in \code{data} are carried into the output as \code{sender_ev} /
+\code{receiver_ev} (the observed event) and \code{sender_nv} / \code{receiver_nv} (the
+matched control), so the dyads behind each case-control pair remain
+recoverable (and become available to \code{re()} grouping terms in \code{\link[=rem]{rem()}}).
+Set to \code{FALSE} to emit only the widened covariate columns.}
 }
 \value{
-A data.frame with one row per case: a \code{stratum} column and, for each
+A data.frame with one row per case: a \code{stratum} column, the
+sender/receiver identifiers (\code{sender_ev}/\code{receiver_ev}/\code{sender_nv}/
+\code{receiver_nv}, when present in \code{data} and \code{keep_ids = TRUE}) and, for each
 covariate, \verb{<cov>_ev}, \verb{<cov>_nv} and \verb{d_<cov>}. Strata without exactly one
 case or without the requested control are dropped (with a message).
 }

--- a/tests/testthat/test-workshop-issues.R
+++ b/tests/testthat/test-workshop-issues.R
@@ -1,0 +1,153 @@
+# Tests for the three workshop-driven fixes (issues #92, #93, #94):
+#   #92  widen_case_control() carries the sender/receiver identifiers through.
+#   #93  rem(method = "gam") widens long-format input instead of fitting garbage.
+#   #94  compute_endogenous_features() gains a prior_log warm-start argument.
+
+make_long <- function(seed = 1, n_events = 200, stat, effect, half_life = NULL) {
+  set.seed(seed)
+  a <- paste0("a", 1:15)
+  args <- list(
+    n_events           = n_events,
+    senders            = a,
+    receivers          = a,
+    baseline_rate      = 1,
+    n_controls         = 1,
+    endogenous_stats   = stat,
+    endogenous_effects = stats::setNames(effect, stat)
+  )
+  if (!is.null(half_life)) args$half_life <- half_life
+  do.call(simulate_relational_events, args)
+}
+
+# ---- #92 -------------------------------------------------------------------
+
+test_that("widen_case_control carries sender/receiver ids (#92)", {
+  cc <- make_long(stat = "reciprocity_count", effect = 0.5)
+  w <- widen_case_control(cc, case = "event", stratum = "stratum")
+
+  expect_true(all(c("sender_ev", "receiver_ev", "sender_nv", "receiver_nv")
+                  %in% names(w)))
+
+  # The carried event ids must match the case rows of the source log, matched
+  # by stratum (robust to row ordering).
+  ev <- cc[cc$event == 1L, ]
+  expect_equal(w$sender_ev,   as.character(ev$sender[match(w$stratum, ev$stratum)]))
+  expect_equal(w$receiver_ev, as.character(ev$receiver[match(w$stratum, ev$stratum)]))
+
+  # The carried control ids must be the matched control's dyad.
+  ct <- cc[cc$event == 0L, ]
+  expect_equal(w$sender_nv,   as.character(ct$sender[match(w$stratum, ct$stratum)]))
+  expect_equal(w$receiver_nv, as.character(ct$receiver[match(w$stratum, ct$stratum)]))
+
+  # keep_ids = FALSE restores the old, id-free output.
+  w0 <- widen_case_control(cc, case = "event", stratum = "stratum",
+                           keep_ids = FALSE)
+  expect_false(any(c("sender_ev", "receiver_ev", "sender_nv", "receiver_nv")
+                   %in% names(w0)))
+})
+
+# ---- #93 -------------------------------------------------------------------
+
+test_that("rem(method = 'gam') auto-widens long-format input (#93)", {
+  skip_if_not_installed("mgcv")
+  raw <- make_long(stat = "reciprocity_exp_decay", effect = 0.8, half_life = 0.1)
+
+  wide <- widen_case_control(raw, case = "event", stratum = "stratum")
+  fit_wide <- rem(~ reciprocity_exp_decay, data = wide, method = "gam")
+
+  # Long input is detected and widened, with a message (not silently wrong).
+  expect_message(
+    fit_long <- rem(~ reciprocity_exp_decay, data = raw, method = "gam"),
+    "long-format"
+  )
+  # And it then reproduces the explicitly-widened fit exactly.
+  expect_equal(unname(coef(fit_long)), unname(coef(fit_wide)))
+
+  # Already-wide data fits without any message.
+  expect_silent(rem(~ reciprocity_exp_decay, data = wide, method = "gam"))
+})
+
+# ---- #94 -------------------------------------------------------------------
+
+test_that("compute_endogenous_features prior_log warm-starts state (#94)", {
+  prior_events <- data.frame(
+    sender = c("A", "B"), receiver = c("B", "C"), time = c(1, 2)
+  )
+  cc_log <- data.frame(
+    sender   = c("A", "B", "C", "C"),
+    receiver = c("C", "C", "A", "A"),
+    time     = c(3,   3,   4,   4),
+    event    = c(1,   0,   1,   0)
+  )
+  stat <- "transitivity_binary_interrupted"
+  events_only <- cc_log[cc_log$event == 1L, c("sender", "receiver", "time")]
+
+  out <- compute_endogenous_features(
+    event_log   = cc_log,
+    prior_log   = prior_events,
+    history_log = events_only,
+    stats       = stat
+  )
+
+  # Prior rows never appear in the output; the event_log is returned intact.
+  expect_equal(nrow(out), nrow(cc_log))
+  expect_equal(out$sender, cc_log$sender)
+  expect_equal(out$time, cc_log$time)
+
+  # The warm-started A -> C event sees the A -> B, B -> C two-path (value 1);
+  # this is the value the documented prepend-and-trim workaround produces.
+  full_log <- rbind(prior_events, cc_log[, c("sender", "receiver", "time")])
+  ref <- compute_endogenous_features(
+    event_log   = full_log,
+    stats       = stat,
+    history_log = rbind(prior_events, events_only)
+  )
+  ref <- ref[ref$time >= 3, ]
+  expect_equal(out[[stat]], ref[[stat]])
+  expect_equal(out[[stat]][1], 1L)   # A -> C is warm-started to 1
+})
+
+test_that("without prior_log the warm-start is lost (#94 motivation)", {
+  prior_events <- data.frame(
+    sender = c("A", "B"), receiver = c("B", "C"), time = c(1, 2)
+  )
+  cc_log <- data.frame(
+    sender   = c("A", "B", "C", "C"),
+    receiver = c("C", "C", "A", "A"),
+    time     = c(3,   3,   4,   4),
+    event    = c(1,   0,   1,   0)
+  )
+  stat <- "transitivity_binary_interrupted"
+  events_only <- cc_log[cc_log$event == 1L, c("sender", "receiver", "time")]
+
+  # Passing the prior events through history_log only (the intuitive-but-wrong
+  # call) does not warm-start the state: A -> C is 0, not 1.
+  wrong <- compute_endogenous_features(
+    event_log   = cc_log,
+    history_log = rbind(prior_events, events_only),
+    stats       = stat
+  )
+  expect_equal(wrong[[stat]][1], 0L)
+})
+
+test_that("prior_log is honoured for the sender_receivers_set list-column (#94)", {
+  prior_events <- data.frame(
+    sender = "X", receiver = "Y", time = 1
+  )
+  ev <- data.frame(
+    sender   = c("X", "X"),
+    receiver = c("Z", "Y"),
+    time     = c(2,   3),
+    event    = c(1,   1)
+  )
+  out <- compute_endogenous_features(
+    event_log = ev,
+    prior_log = prior_events,
+    stats     = "sender_receivers_set"
+  )
+  expect_equal(nrow(out), 2L)
+  # Before its first in-window event, X has already reached Y (from prior_log).
+  expect_equal(sort(out$sender_receivers_set[[1]]), "Y")
+  # Before the second event, X has reached Y (prior) and Z (first event).
+  expect_equal(sort(out$sender_receivers_set[[2]]), c("Y", "Z"))
+})


### PR DESCRIPTION
Addresses the three issues opened ahead of the Sunbelt workshop. All three are package-side fixes with tests; the workshop-script PRs (#95–#98) are independent.

## #92 — `widen_case_control()` drops sender/receiver
Carry the sender/receiver of both the case and its matched control into the wide output as `sender_ev`/`receiver_ev`/`sender_nv`/`receiver_nv`. New `keep_ids = TRUE` argument controls this. The dyads behind each case-control pair are no longer lost, and `re()` grouping terms in `rem()` can now reach the actor levels.

## #93 — `rem(method = "gam")` silently wrong on long-format data
`rem(method = "gam")` now detects long-format input (an `event`/`IS_OBSERVED` indicator carrying control rows) and widens it via `widen_case_control()` **with a message**, instead of silently misreading raw per-row covariate values as event-minus-control differences. Already-wide input fits unchanged and silently.

## #94 — `compute_endogenous_features()`: warm-start vs. masking
New `prior_log` argument for warm-starting the network state from events that precede the study window: its rows update the running state but never appear in the output. This separates warm-starting from the non-event masking role of `history_log`, internalizing the documented prepend-and-trim recipe. Honoured by both the C++ stat engine and the `sender_receivers_set` list-column.

## Tests
`tests/testthat/test-workshop-issues.R` covers all three (id carry-through + `keep_ids=FALSE`; gam auto-widen reproduces the explicit-widen fit and emits the message; `prior_log` matches the manual workaround and warm-starts `transitivity_binary_interrupted` and `sender_receivers_set`). Full suite: 0 failures.

Closes #92
Closes #93
Closes #94